### PR TITLE
Make normalizr also copy Symbol keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,14 @@ import isObject from 'lodash/isObject';
 import isEqual from 'lodash/isEqual';
 import mapValues from 'lodash/mapValues';
 
+function getAllOwnPropertyKeys (obj) {
+  return Object.keys(obj).concat(
+    typeof Object.getOwnPropertySymbols === 'function'
+      ? Object.getOwnPropertySymbols(obj)
+      : []
+  )
+}
+
 function defaultAssignEntity(normalized, key, entity) {
   normalized[key] = entity;
 }
@@ -13,11 +21,9 @@ function visitObject(obj, schema, bag, options) {
   const { assignEntity = defaultAssignEntity } = options;
 
   let normalized = {};
-  for (let key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      const entity = visit(obj[key], schema[key], bag, options);
-      assignEntity.call(null, normalized, key, entity);
-    }
+  for (let key of getAllOwnPropertyKeys(obj)) {
+    const entity = visit(obj[key], schema[key], bag, options);
+    assignEntity.call(null, normalized, key, entity);
   }
   return normalized;
 }
@@ -51,7 +57,7 @@ function visitUnion(obj, unionSchema, bag, options) {
 }
 
 function defaultMergeIntoEntity(entityA, entityB, entityKey) {
-  for (let key in entityB) {
+  for (let key of getAllOwnPropertyKeys(entityB)) {
     if (!entityB.hasOwnProperty(key)) {
       continue;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ function getAllOwnPropertyKeys (obj) {
     typeof Object.getOwnPropertySymbols === 'function'
       ? Object.getOwnPropertySymbols(obj)
       : []
-  )
+  );
 }
 
 function defaultAssignEntity(normalized, key, entity) {

--- a/test/index.js
+++ b/test/index.js
@@ -85,6 +85,31 @@ describe('normalizr', function () {
     });
   });
 
+  it('can normalize an entity with Symbol keys', function () {
+    var article = new Schema('articles'),
+        input,
+        TYPE = Symbol();
+
+    input = {
+      id: 1,
+      title: 'Some Article',
+      isFavorite: false,
+      [TYPE]: 'article'
+    };
+
+    Object.freeze(input);
+    article.getIdAttribute().should.eql('id');
+    article.getKey().should.eql('articles');
+
+    const normalized = normalize(input, article)
+
+    // This is a bit rough, but mocha doesn't know how to check
+    // for Symbol keys, and has to be talked through it.
+    const entityType = normalized.entities.articles['1'][TYPE]
+    should.exist(entityType)
+    entityType.should.eql('article')
+  });
+
   it('can normalize nested entity and delete an existing key using custom function', function () {
     var article = new Schema('articles'),
         type = new Schema('types'),

--- a/test/index.js
+++ b/test/index.js
@@ -101,13 +101,13 @@ describe('normalizr', function () {
     article.getIdAttribute().should.eql('id');
     article.getKey().should.eql('articles');
 
-    const normalized = normalize(input, article)
+    const normalized = normalize(input, article);
 
     // This is a bit rough, but mocha doesn't know how to check
     // for Symbol keys, and has to be talked through it.
-    const entityType = normalized.entities.articles['1'][TYPE]
-    should.exist(entityType)
-    entityType.should.eql('article')
+    const entityType = normalized.entities.articles['1'][TYPE];
+    should.exist(entityType);
+    entityType.should.eql('article');
   });
 
   it('can normalize nested entity and delete an existing key using custom function', function () {


### PR DESCRIPTION
So in the application I work on, we use normalizr both to slice up entities from the initial server response, and also internally to prepare nested entities constructed within forms to be merged into the entity branch of the state tree. We also use a Symbol key on our data objects in order to dispatch based on categorization at various places within the app. At present I need to "retag" objects with their appropriate category symbol key after they pass through normalizr. It would be nice if normalizr knew how to just copy Symbol keys.

I've made a couple of small changes to enable this that I don't *think* should present any significant downsides. I did use Object.keys to get the objects own string keys. I'm not sure if you were going for ES3 backward compatibility there, but it wouldn't be hard to replace with a `for... in` if you'd rather.

Sorry that the test I added is a bit weird. Mocha apparently only knows how to check for string keyed props at the moment, and so needs a little hand-holding to check for Symbols.

thoughts, feelings?