### PR TITLE
provide schema in assignEntity

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ const article = new Schema('articles', { idAttribute: 'slug' });
 // Or you can specify a function to infer it
 function generateSlug(entity) { /* ... */ }
 const article = new Schema('articles', { idAttribute: generateSlug });
+
+// You can also specify meta properties to be used for customizing the output in assignEntity (see below)
+const article = new Schema('articles', { idAttribute: 'slug', meta: { removeProps: ['publisher'] }});
 ```
 
 ### `Schema.prototype.define(nestedSchema)`

--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -9,6 +9,7 @@ export default class EntitySchema {
     const idAttribute = options.idAttribute || 'id';
     this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
     this._idAttribute = idAttribute;
+    this._meta = options.meta;
   }
 
   getKey() {
@@ -21,6 +22,13 @@ export default class EntitySchema {
 
   getIdAttribute() {
     return this._idAttribute;
+  }
+
+  getMeta(prop) {
+    if (!prop || typeof prop !== 'string') {
+      throw new Error('A string non-empty property name is required');
+    }
+    return this._meta && this._meta[prop];
   }
 
   define(nestedSchema) {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function visitObject(obj, schema, bag, options) {
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
       const entity = visit(obj[key], schema[key], bag, options);
-      assignEntity.call(null, normalized, key, entity, obj);
+      assignEntity.call(null, normalized, key, entity, obj, schema);
     }
   }
   return normalized;


### PR DESCRIPTION
This PR is a small change to provide ```schema``` as an argument to the ```assignEntity``` function. 

My use-case is that when normalizing entities I want the key to be present under a different name in certain circumstances. I need to support both normalized and denormalized data and having fields with the same name but different types is causing quite a lot of confusion and noise.

With this change I can flag the schemas which I want to be assigned with a new name and then override the assignEntity method. See the added test for an example of this working.

Happy to discuss or make changes if you want, many thanks.