### PR TITLE
Update lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "webpack": "^1.10.5"
   },
   "dependencies": {
-    "lodash": "^4.0.0"
+    "lodash": "^4.11.2"
   }
 }


### PR DESCRIPTION
**Problem:**

Using lodash@4.7.0, we encountered an error with Firefox versions < 46 in which lodash would have an error initializing `lodash/isEqual`.

**Solution:**

So, any version greater than 4.0.0 was not necessarily compatible. This update fixes the issue.