### PR TITLE
Allow EntitySchema-specific assignEntity fns

### DIFF
--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -5,11 +5,16 @@ export default class EntitySchema {
     }
 
     this._key = key;
+    this._assignEntity = options.assignEntity;
 
     const idAttribute = options.idAttribute || 'id';
     this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
     this._idAttribute = idAttribute;
     this._meta = options.meta;
+  }
+
+  getAssignEntity() {
+    return this._assignEntity;
   }
 
   getKey() {

--- a/src/UnionSchema.js
+++ b/src/UnionSchema.js
@@ -20,6 +20,7 @@ export default class UnionSchema {
     return this._itemSchema;
   }
 
+
   getSchemaKey(item) {
     return this._getSchema(item);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,10 @@ function visitObject(obj, schema, bag, options) {
     if (obj.hasOwnProperty(key)) {
       const schemaAssignEntity = schema && schema.getAssignEntity && schema.getAssignEntity();
       const entity = visit(obj[key], schema[key], bag, options);
-      (schemaAssignEntity || assignEntity).call(null, normalized, key, entity, obj, schema);
+      assignEntity.call(null, normalized, key, entity, obj, schema);
+      if (schemaAssignEntity) {
+        schemaAssignEntity.call(null, normalized, key, entity, obj, schema);
+      }
     }
   }
   return normalized;

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,9 @@ function visitObject(obj, schema, bag, options) {
   let normalized = {};
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
+      const schemaAssignEntity = schema && schema.getAssignEntity && schema.getAssignEntity();
       const entity = visit(obj[key], schema[key], bag, options);
-      assignEntity.call(null, normalized, key, entity, obj, schema);
+      (schemaAssignEntity || assignEntity).call(null, normalized, key, entity, obj, schema);
     }
   }
   return normalized;

--- a/test/index.js
+++ b/test/index.js
@@ -391,6 +391,9 @@ describe('normalizr', function () {
         assignEntity: function(obj, key, val) {
           if (key === 'collections') {
             obj['collection_ids'] = val;
+            if ('collections' in obj) {
+              delete obj['collections'];
+            }
           } else {
             obj[key] = val;
           }

--- a/test/index.js
+++ b/test/index.js
@@ -207,7 +207,7 @@ describe('normalizr', function () {
     article.define({
       authors: arrayOf(author)
     });
-    
+
     input = {
       id: '123',
       title: 'My article',
@@ -226,9 +226,9 @@ describe('normalizr', function () {
 
     var options = {
       assignEntity: function (obj, key, val, originalInput, schema) {
-        var itemSchema = schema && schema.getItemSchema ? schema.getItemSchema() : schema;         
+        var itemSchema = schema && schema.getItemSchema ? schema.getItemSchema() : schema;
         var removeProps = itemSchema && itemSchema.getMeta && itemSchema.getMeta("removeProps");
-        if (!removeProps || removeProps.indexOf(key) < 0)        
+        if (!removeProps || removeProps.indexOf(key) < 0)
           obj[key] = val;
       }
     };
@@ -257,6 +257,190 @@ describe('normalizr', function () {
     });
   });
 
+  it('can use EntitySchema-specific assignEntity function', function () {
+    var taco = new Schema('tacos', { assignEntity: function (output, key, value, input) {
+      if (key === 'filling') {
+        output[key] = 'veggie';
+        return;
+      }
+      output[key] = value;
+    }});
+
+    var input = Object.freeze({
+      id: '123',
+      type: 'hardshell',
+      filling: 'beef'
+    });
+
+    normalize(input, taco).should.eql({
+      entities: {
+        tacos: {
+          '123': { id: '123', type: 'hardshell', filling: 'veggie' }
+        }
+      },
+      result: '123'
+    });
+  });
+
+  it('can use UnionSchema-specific assignEntity function', function () {
+    var user = new Schema('users'),
+        group = new Schema('groups', { assignEntity: function (output, key, value, input) {
+            if (key === 'name') {
+              output.url = '/groups/' + value;
+            }
+            output[key] = value;
+          }
+        }),
+        member = unionOf({ users: user, groups: group }, { schemaAttribute: 'type' }),
+        input;
+
+    group.define({
+      members: arrayOf(member),
+      owner: member,
+      relations: valuesOf(member)
+    });
+
+    input = {
+      group: {
+        id: 1,
+        name: 'facebook',
+        members: [{
+          id: 2,
+          type: 'groups',
+          name: 'react'
+        }, {
+          id: 3,
+          type: 'users',
+          name: 'Huey'
+        }],
+        owner: {
+          id: 4,
+          type: 'users',
+          name: 'Jason'
+        },
+        relations: {
+          friend: {
+            id: 5,
+            type: 'users',
+            name: 'Nate'
+          }
+        }
+      }
+    };
+
+    Object.freeze(input);
+
+    normalize(input, { group: group }).should.eql({
+      result: {
+        group: 1
+      },
+      entities: {
+        groups: {
+          1: {
+            id: 1,
+            name: 'facebook',
+            members: [{
+              id: 2,
+              schema: 'groups'
+            }, {
+              id: 3,
+              schema: 'users'
+            }],
+            owner: {
+              id: 4,
+              schema: 'users'
+            },
+            relations: {
+              friend: {
+                id: 5,
+                schema: 'users'
+              }
+            },
+            url: '/groups/facebook'
+          },
+          2: {
+            id: 2,
+            type: 'groups',
+            name: 'react',
+            url: '/groups/react'
+          }
+        },
+        users: {
+          3: {
+            id: 3,
+            type: 'users',
+            name: 'Huey'
+          },
+          4: {
+            id: 4,
+            type: 'users',
+            name: 'Jason'
+          },
+          5: {
+            id: 5,
+            type: 'users',
+            name: 'Nate'
+          }
+        }
+      }
+    });
+  });
+
+  it('can use Schema-specific assignEntity function in iterables', function () {
+    var article = new Schema('articles', {
+        assignEntity: function(obj, key, val) {
+          if (key === 'collections') {
+            obj['collection_ids'] = val;
+          } else {
+            obj[key] = val;
+          }
+        }
+      }),
+      collection = new Schema('collections'),
+      input;
+
+    article.define({
+      collections: arrayOf(collection)
+    });
+
+    input = {
+      id: 1,
+      title: 'Some Article',
+      collections: [{
+        id: 1,
+        title: 'Awesome Writing',
+      }, {
+        id: 7,
+        title: 'Even Awesomer',
+      }]
+    };
+
+    Object.freeze(input);
+
+    normalize(input, article).should.eql({
+      result: 1,
+      entities: {
+        articles: {
+          1: {
+            id: 1,
+            title: 'Some Article',
+            collection_ids: [1, 7]
+          },
+        },
+        collections: {
+          1: {
+            id: 1,
+            title: 'Awesome Writing',
+          },
+          7: {
+            id: 7,
+            title: 'Even Awesomer',
+          }
+        },
+      }
+    });
+  });
+
   it('throws if getMeta is called with invalid params', function () {
     var article = new Schema('articles', { meta: { removeProps: ['year', 'publisher'] }});
 
@@ -276,7 +460,7 @@ describe('normalizr', function () {
       article.getMeta('removeProps');
     }).should.not.throw();
   });
-  
+
   it('can merge into entity using custom function', function () {
     var author = new Schema('authors'),
         input;


### PR DESCRIPTION
This allows custom `assignEntity` functions on `EntitySchema`s.

**Problem:**

When dealing with many endpoints and normalizing across a lot of different schema, a single `assignEntity` function needs too many checks to determine whether it should have different behavior for particular keys. Often times, multiple schema will have the same keys but not need to be assigned the same way.

**Solution:**

Add an `assignEntity` option to `Schema`/`EntitySchema` that runs after the main `assignEntity` option passed to `normalize`.

Alternative to #97
