### PR TITLE
README typofix`valueOf`=> `valuesOf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ group.define({
 });
 ```
 
-A `unionOf` schema can also be combined with `arrayOf` and `valueOf` with the same behavior as each supplied with the `schemaAttribute` option.
+A `unionOf` schema can also be combined with `arrayOf` and `valuesOf` with the same behavior as each supplied with the `schemaAttribute` option.
 
 ```javascript
 const group = new Schema('groups');


### PR DESCRIPTION
# Problem

Fixes a simple typo in the README in the section for `unionOf`.  
