### PR TITLE
Polymorphic item creator

### DIFF
--- a/src/IterableSchema.js
+++ b/src/IterableSchema.js
@@ -9,7 +9,8 @@ export default class ArraySchema {
 
     if (options.schemaAttribute) {
       const schemaAttribute = options.schemaAttribute;
-      this._itemSchema = new UnionSchema(itemSchema, { schemaAttribute })
+      const polymorphicItem = options.polymorphicItem;
+      this._itemSchema = new UnionSchema(itemSchema, { schemaAttribute, polymorphicItem })
     } else {
       this._itemSchema = itemSchema;
     }

--- a/src/IterableSchema.js
+++ b/src/IterableSchema.js
@@ -9,8 +9,8 @@ export default class ArraySchema {
 
     if (options.schemaAttribute) {
       const schemaAttribute = options.schemaAttribute;
-      const polymorphicItem = options.polymorphicItem;
-      this._itemSchema = new UnionSchema(itemSchema, { schemaAttribute, polymorphicItem })
+      const polymorphic = options.polymorphic;
+      this._itemSchema = new UnionSchema(itemSchema, { schemaAttribute, polymorphic })
     } else {
       this._itemSchema = itemSchema;
     }

--- a/src/UnionSchema.js
+++ b/src/UnionSchema.js
@@ -15,11 +15,7 @@ export default class UnionSchema {
     const schemaAttribute = options.schemaAttribute;
     this._getSchema = typeof schemaAttribute === 'function' ? schemaAttribute : x => x[schemaAttribute];
 
-    function defaultPolymorphicItem(item) {
-      return { schema: this._getSchema(item) };
-    }
-
-    this._getSchemaKeys = options.polymorphicItem || defaultPolymorphicItem;
+    this._getPolimorphicItem = options.polymorphicItem || ( () => ({}) );
   }
 
   getItemSchema() {
@@ -30,7 +26,7 @@ export default class UnionSchema {
     return this._getSchema(item);
   }
 
-  getSchemaKeys(item) {
-    return this._getSchemaKeys(item);
+  getPolimorphicItem(item) {
+    return this._getPolimorphicItem(item);
   }
 }

--- a/src/UnionSchema.js
+++ b/src/UnionSchema.js
@@ -15,7 +15,7 @@ export default class UnionSchema {
     const schemaAttribute = options.schemaAttribute;
     this._getSchema = typeof schemaAttribute === 'function' ? schemaAttribute : x => x[schemaAttribute];
 
-    this._getPolimorphicItem = options.polymorphicItem || ( () => ({}) );
+    this._getPolymorphic = options.polymorphic || ( () => ({}) );
   }
 
   getItemSchema() {
@@ -26,7 +26,7 @@ export default class UnionSchema {
     return this._getSchema(item);
   }
 
-  getPolimorphicItem(item) {
-    return this._getPolimorphicItem(item);
+  getPolymorphic(item) {
+    return this._getPolymorphic(item);
   }
 }

--- a/src/UnionSchema.js
+++ b/src/UnionSchema.js
@@ -14,14 +14,23 @@ export default class UnionSchema {
 
     const schemaAttribute = options.schemaAttribute;
     this._getSchema = typeof schemaAttribute === 'function' ? schemaAttribute : x => x[schemaAttribute];
+
+    function defaultPolymorphicItem(item) {
+      return { schema: this._getSchema(item) };
+    }
+
+    this._getSchemaKeys = options.polymorphicItem || defaultPolymorphicItem;
   }
 
   getItemSchema() {
     return this._itemSchema;
   }
 
-
   getSchemaKey(item) {
     return this._getSchema(item);
+  }
+
+  getSchemaKeys(item) {
+    return this._getSchemaKeys(item);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import IterableSchema from './IterableSchema';
 import UnionSchema from './UnionSchema';
 import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
-import merge from 'lodash/merge';
 
 function defaultAssignEntity(normalized, key, entity) {
   normalized[key] = entity;
@@ -32,10 +31,10 @@ function defaultMapper(iterableSchema, itemSchema, bag, options) {
 
 function polymorphicMapper(iterableSchema, itemSchema, bag, options) {
   return (obj) => {
-    const polimorphicItemKeys = iterableSchema.getPolimorphicItem(obj);
+    const polymorphicItemKeys = iterableSchema.getPolymorphic(obj);
     const schemaKey = iterableSchema.getSchemaKey(obj);
     const result = visit(obj, itemSchema[schemaKey], bag, options);
-    return merge({ id: result, schema: schemaKey }, polimorphicItemKeys);
+    return { ...polymorphicItemKeys, id: result, schema: schemaKey };
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,10 +32,10 @@ function defaultMapper(iterableSchema, itemSchema, bag, options) {
 
 function polymorphicMapper(iterableSchema, itemSchema, bag, options) {
   return (obj) => {
-    const schemaKeys = iterableSchema.getSchemaKeys(obj);
+    const polimorphicItemKeys = iterableSchema.getPolimorphicItem(obj);
     const schemaKey = iterableSchema.getSchemaKey(obj);
     const result = visit(obj, itemSchema[schemaKey], bag, options);
-    return merge({ id: result }, schemaKeys);
+    return merge({ id: result, schema: schemaKey }, polimorphicItemKeys);
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import IterableSchema from './IterableSchema';
 import UnionSchema from './UnionSchema';
 import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
+import merge from 'lodash/merge';
 
 function defaultAssignEntity(normalized, key, entity) {
   normalized[key] = entity;
@@ -31,9 +32,10 @@ function defaultMapper(iterableSchema, itemSchema, bag, options) {
 
 function polymorphicMapper(iterableSchema, itemSchema, bag, options) {
   return (obj) => {
+    const schemaKeys = iterableSchema.getSchemaKeys(obj);
     const schemaKey = iterableSchema.getSchemaKey(obj);
     const result = visit(obj, itemSchema[schemaKey], bag, options);
-    return { id: result, schema: schemaKey };
+    return merge({ id: result }, schemaKeys);
   };
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -732,7 +732,7 @@ describe('normalizr', function () {
         input;
 
     function polymorphicItem(item) {
-      return { schema: item.type, releaseDate: item.releaseDate };
+      return { releaseDate: item.releaseDate };
     }
 
     magazine.define({

--- a/test/index.js
+++ b/test/index.js
@@ -724,19 +724,19 @@ describe('normalizr', function () {
     });
   });
 
-  it('can normalize a polymorphic array with schema attribute and polymorphicItemCreator', function () {
+  it('can normalize a polymorphic array with schema attribute and polymorphicCreator', function () {
     var article = new Schema('articles'),
         tutorial = new Schema('tutorials'),
         magazine = new Schema('magazines'),
         articleOrTutorial = { articles: article, tutorials: tutorial },
         input;
 
-    function polymorphicItem(item) {
+    function polymorphic(item) {
       return { releaseDate: item.releaseDate };
     }
 
     magazine.define({
-      contents: arrayOf(articleOrTutorial, { schemaAttribute: 'type', polymorphicItem: polymorphicItem } )
+      contents: arrayOf(articleOrTutorial, { schemaAttribute: 'type', polymorphic: polymorphic } )
     });
 
     input = [

--- a/test/index.js
+++ b/test/index.js
@@ -724,6 +724,159 @@ describe('normalizr', function () {
     });
   });
 
+  it('can normalize a polymorphic array with schema attribute and polymorphicItemCreator', function () {
+    var article = new Schema('articles'),
+        tutorial = new Schema('tutorials'),
+        magazine = new Schema('magazines'),
+        articleOrTutorial = { articles: article, tutorials: tutorial },
+        input;
+
+    function polymorphicItem(item) {
+      return { schema: item.type, releaseDate: item.releaseDate };
+    }
+
+    magazine.define({
+      contents: arrayOf(articleOrTutorial, { schemaAttribute: 'type', polymorphicItem: polymorphicItem } )
+    });
+
+    input = [
+      {
+        id: 1,
+        name: 'my magazine',
+        contents: [
+          {
+            id: 1,
+            type: 'articles',
+            title: 'Some Article',
+            releaseDate: '01/01/2016'
+          }, {
+            id: 2,
+            type: 'articles',
+            title: 'Another Article',
+            releaseDate: '10/01/2016'
+          }, {
+            id: 1,
+            type: 'tutorials',
+            title: 'Some tutorial',
+            releaseDate: '10/01/2016'
+          }
+        ]
+      }, {
+        id: 2,
+        name: 'your magazine',
+        contents: [
+          {
+            id: 1,
+            type: 'articles',
+            title: 'Some Article',
+            releaseDate: '15/01/2016'
+          }, {
+            id: 2,
+            type: 'articles',
+            title: 'Another Article',
+            releaseDate: '25/01/2016'
+          }, {
+            id: 1,
+            type: 'tutorials',
+            title: 'Some tutorial',
+            releaseDate: '25/01/2016'
+          }
+        ]
+      }
+    ];
+
+    var options = {
+      mergeIntoEntity: function(entityA, entityB, entityKey) {
+        var key;
+
+        for (key in entityB) {
+          if (!entityB.hasOwnProperty(key)) {
+            continue;
+          }
+
+          if (!entityA.hasOwnProperty(key) || isEqual(entityA[key], entityB[key])) {
+            entityA[key] = entityB[key];
+            continue;
+          }
+
+          if (key === 'releaseDate') {
+            delete entityA[key]
+            continue;
+          }
+
+          console.warn('Unequal data!');
+        }
+      }
+    };
+
+    Object.freeze(input);
+
+    normalize(input, arrayOf(magazine), options).should.eql({
+      result: [1, 2],
+      entities: {
+        articles: {
+          1: {
+            id: 1,
+            type: 'articles',
+            title: 'Some Article'
+          },
+          2: {
+            id: 2,
+            type: 'articles',
+            title: 'Another Article'
+          }
+        },
+        magazines: {
+          1: {
+            id: 1,
+            name: 'my magazine',
+            contents: [
+              {
+                id: 1,
+                schema: 'articles',
+                releaseDate: '01/01/2016'
+              }, {
+                id: 2,
+                schema: 'articles',
+                releaseDate: '10/01/2016'
+              }, {
+                id: 1,
+                schema: 'tutorials',
+                releaseDate: '10/01/2016'
+              }
+            ]
+          },
+          2: {
+            id: 2,
+            name: 'your magazine',
+            contents: [
+              {
+                id: 1,
+                schema: 'articles',
+                releaseDate: '15/01/2016'
+              }, {
+                id: 2,
+                schema: 'articles',
+                releaseDate: '25/01/2016'
+              }, {
+                id: 1,
+                schema: 'tutorials',
+                releaseDate: '25/01/2016'
+              }
+            ]
+          }
+        },
+        tutorials: {
+          1: {
+            id: 1,
+            type: 'tutorials',
+            title: 'Some tutorial'
+          }
+        }
+      }
+    });
+  });
+
   it('can normalize a map', function () {
     var article = new Schema('articles'),
         input;


### PR DESCRIPTION
# Problem

Related to [issue#116](https://github.com/paularmstrong/normalizr/issues/116).

The same entity has different values of a specific attribute depending on where that entity comes from.

When we normalize the input, we get merge conflict with the releaseDate. We lose the information regarding the specifics of that article or tutorial related to its magazine. The articles are the same and I want to keep them as the same entity. But I'd like to also keep the value that is specific of that article related with the magazine.

# Solution

Provide a `polymorphicItem` key with a function on polymorphicMaps. That function will add more keys to the reference object.
```js
  function polymorphicItem(item) {
    return { releaseDate: item.releaseDate };
  }

  magazine.define({
    contents: arrayOf(articleOrTutorial, { schemaAttribute: 'type', polymorphicItem: polymorphicItem } )
  });
```

I hope this is clear enough 😺 
