### PR TITLE
(feat) add ability to dynamically set nested schema type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,9 @@ function visitObject(obj, schema, bag, options) {
   let normalized = {};
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
+      const resolvedSchema = typeof schema[key] === 'function' ? schema[key].call(null, obj) : schema[key];
       const schemaAssignEntity = schema && schema.getAssignEntity && schema.getAssignEntity();
-      const entity = visit(obj[key], schema[key], bag, options);
+      const entity = visit(obj[key], resolvedSchema, bag, options);
       assignEntity.call(null, normalized, key, entity, obj, schema);
       if (schemaAssignEntity) {
         schemaAssignEntity.call(null, normalized, key, entity, obj, schema);

--- a/test/index.js
+++ b/test/index.js
@@ -877,40 +877,48 @@ describe('normalizr', function () {
     });
   });
 
-  it('can normalize nested entities', function () {
-    var article = new Schema('articles'),
-        user = new Schema('users'),
+  it('can normalize nested entity using property from parent', function () {
+    var linkablesSchema = new Schema('linkables'),
+        mediaSchema = new Schema('media'),
+        listsSchema = new Schema('lists'),
         input;
 
-    article.define({
-      author: user
+    var schemaMap = {
+      media: mediaSchema,
+      lists: listsSchema
+    };
+
+    linkablesSchema.define({
+      data: (parent) => schemaMap[parent.schema_type]
     });
 
     input = {
       id: 1,
-      title: 'Some Article',
-      author: {
-        id: 3,
-        name: 'Mike Persson'
+      module_type: 'article',
+      schema_type: 'media',
+      data: {
+        id: 2,
+        url: 'catimage.jpg'
       }
     };
 
     Object.freeze(input);
 
-    normalize(input, article).should.eql({
+    normalize(input, linkablesSchema).should.eql({
       result: 1,
       entities: {
-        articles: {
+        linkables: {
           1: {
             id: 1,
-            title: 'Some Article',
-            author: 3
+            module_type: 'article',
+            schema_type: 'media',
+            data: 2
           }
         },
-        users: {
-          3: {
-            id: 3,
-            name: 'Mike Persson'
+        media: {
+          2: {
+            id: 2,
+            url: 'catimage.jpg'
           }
         }
       }

--- a/test/index.js
+++ b/test/index.js
@@ -877,6 +877,46 @@ describe('normalizr', function () {
     });
   });
 
+  it('can normalize nested entities', function () {
+    var article = new Schema('articles'),
+        user = new Schema('users'),
+        input;
+
+    article.define({
+      author: user
+    });
+
+    input = {
+      id: 1,
+      title: 'Some Article',
+      author: {
+        id: 3,
+        name: 'Mike Persson'
+      }
+    };
+
+    Object.freeze(input);
+
+    normalize(input, article).should.eql({
+      result: 1,
+      entities: {
+        articles: {
+          1: {
+            id: 1,
+            title: 'Some Article',
+            author: 3
+          }
+        },
+        users: {
+          3: {
+            id: 3,
+            name: 'Mike Persson'
+          }
+        }
+      }
+    });
+  });
+
   it('can normalize nested entity using property from parent', function () {
     var linkablesSchema = new Schema('linkables'),
         mediaSchema = new Schema('media'),
@@ -924,6 +964,7 @@ describe('normalizr', function () {
       }
     });
   });
+
 
   it('can normalize deeply nested entities with arrays', function () {
     var article = new Schema('articles'),
@@ -1828,3 +1869,5 @@ describe('normalizr', function () {
   });
 
 });
+
+


### PR DESCRIPTION
# Problem

There is currently no way to set nested schema type depending on some value from the parent schema. https://github.com/paularmstrong/normalizr/issues/130#issuecomment-230622131

# Solution

This PR adds ability to pass a function to `define`s object values, for example 

```javascript
var articleSchema = new Schema('article');
var mediaSchema = new Schema('media');
var listsSchema = new Schema('lists');

var schemaMap = {
  media: mediaSchema,
  lists: listsSchema
};

articleSchema.define({
  foo: (article) => schemaMap[article.type]
});
```



