### PR TITLE
It should be possible to use relations

### DIFF
--- a/src/RelationshipSchema.js
+++ b/src/RelationshipSchema.js
@@ -1,0 +1,29 @@
+import IterableSchema from './IterableSchema';
+
+export default class RelationshipSchema {
+    constructor(key, schema = {}, options = {}) {
+        if (!key || typeof key !== 'string') {
+            throw new Error('A string non-empty key is required');
+        }
+
+        this._key = key;
+        
+        if (schema instanceof IterableSchema) {
+            this._schema = schema;
+        } else {
+            this._schema = new IterableSchema(schema, options);
+        }
+
+        const idAttribute = options.idAttribute || 'id';
+        this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
+        this._idAttribute = idAttribute;
+    }
+
+    getKey() {
+        return this._key;
+    }
+
+    getId(parentEntity) {
+        return this._getId(parentEntity);
+    }
+}


### PR DESCRIPTION
# Problem

Some objects have arrays with objects, which does not have a identifier, and is
tightly coupled to the parent object.

I created a issue here: #134
# Solution

It should possible to mark those objects as a relation to the parent object
and use the parent object id as the identifier when normalizing
# TODO
- [x] Add & Update Tests
### Use case

See updated test
