### PR TITLE
Feature - Opportunity to add properties after assignEntity

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,9 @@ export type ExtractAttribute =
 export type AssignEntity =
   (output: any, key: string, value: any, input: any, schema: SchemaValue) => void;
 
+export type AssignEntityCompleted =
+  (output: any) => void;
+
 export type MergeIntoEntity =
   (entityA: any, entityB: any, entityKey: string) => void;
 
@@ -11,6 +14,7 @@ export type SchemaOptions = {
   idAttribute?: string | ExtractAttribute;
   meta?: any;
   assignEntity?: AssignEntity;
+  assignEntityCompleted?: AssignEntityCompleted;
 }
 
 export type IterableSchemaOptions = {

--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -6,6 +6,7 @@ export default class EntitySchema {
 
     this._key = key;
     this._assignEntity = options.assignEntity;
+    this._assignEntityCompleted = options.assignEntityCompleted;
 
     const idAttribute = options.idAttribute || 'id';
     this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
@@ -16,6 +17,10 @@ export default class EntitySchema {
 
   getAssignEntity() {
     return this._assignEntity;
+  }
+
+  getAssignEntityCompleted() {
+    return this._assignEntityCompleted;
   }
 
   getKey() {
@@ -36,7 +41,7 @@ export default class EntitySchema {
     }
     return this._meta && this._meta[prop];
   }
-  
+
   getDefaults() {
     return this._defaults;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,11 @@ function defaultAssignEntity(normalized, key, entity) {
 }
 
 function visitObject(obj, schema, bag, options) {
-  const { assignEntity = defaultAssignEntity } = options;
+  const { assignEntity = defaultAssignEntity, assignEntityCompleted } = options;
 
   const defaults = schema && schema.getDefaults && schema.getDefaults();
   const schemaAssignEntity = schema && schema.getAssignEntity && schema.getAssignEntity();
+  const schemaAssignEntityCompleted = schema && schema.getAssignEntityCompleted && schema.getAssignEntityCompleted();
   let normalized = isObject(defaults) ? { ...defaults } : {};
   for (let key in obj) {
     if (obj.hasOwnProperty(key)) {
@@ -22,6 +23,12 @@ function visitObject(obj, schema, bag, options) {
         schemaAssignEntity.call(null, normalized, key, entity, obj, schema);
       }
     }
+  }
+  if (assignEntityCompleted) {
+    assignEntityCompleted.call(null, normalized);
+  }
+  if (schemaAssignEntityCompleted) {
+    schemaAssignEntityCompleted.call(null, normalized);
   }
   return normalized;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -249,6 +249,52 @@ describe('normalizr', function () {
     });
   });
 
+  it('can update the entity with custom properties after the being visited', function () {
+    var article = new Schema('articles'),
+        author = new Schema('authors'),
+        input;
+
+    article.define({
+      author: author
+    });
+
+    input = {
+      id: '123',
+      title: 'My article',
+      author: {
+        id: '321',
+        screenName: 'paul'
+      }
+    };
+
+    var options = {
+      assignEntityCompleted: function (obj) {
+        obj.hashcode = `hashed_${obj.id}`;
+      }
+    };
+
+    normalize(input, article, options).should.eql({
+      entities: {
+        articles: {
+          '123': {
+            id: '123',
+            title: 'My article',
+            author: '321',
+            hashcode: 'hashed_123'
+          }
+        },
+        authors: {
+          '321': {
+            id: '321',
+            screenName: 'paul',
+            hashcode: 'hashed_321'
+          }
+        }
+      },
+      result: '123'
+    });
+  });
+
   it('can specify meta properties on a schema which are then accessible in assignEntity', function () {
     var article = new Schema('articles', { meta: { removeProps: ['year', 'publisher'] }}),
         author = new Schema('authors', { meta: { removeProps: ['born'] }}),
@@ -491,6 +537,27 @@ describe('normalizr', function () {
           }
         },
       }
+    });
+  });
+
+  it('can use EntitySchema-specific assignEntityCompleted function', function () {
+    var taco = new Schema('tacos', { assignEntityCompleted: function (output) {
+      output.hashcode = `hashed_${output.id}`;
+    }});
+
+    var input = Object.freeze({
+      id: '123',
+      type: 'hardshell',
+      filling: 'beef'
+    });
+
+    normalize(input, taco).should.eql({
+      entities: {
+        tacos: {
+          '123': { id: '123', type: 'hardshell', filling: 'beef', hashcode: 'hashed_123' }
+        }
+      },
+      result: '123'
     });
   });
 


### PR DESCRIPTION
# Problem

`assignEntity` is great for transforming individual values for particular keys, or using an individual key and value to derive a new one. But what if there's a value that depends on multiple keys and values, or after the model has been fully processed by `assignEntity`? 

I have a situation where there's a handful of fields that are required to derive a value for a particular key on the entity. The best place for this to happen would be _after_ the individual properties have been processed by `assignEntity`.

A simple example would be to compute a `hash` based on a set of fields for efficient comparisons downstream. 

Currently the only way to do this would be to check if the object contains the necessary keys in `assignEntity`:

```js
assignEntity (obj, key, value) {
  if (obj.a && obj.b && obj.c && obj.d) {
    // if these fields are needed to perform a calculation, the only way to know
    // that they have been processed is by checking their truthiness together.
    
    obj.hash = hashingFn(obj.a, obj.b, obj.c, obj.d);
  }
}
```

# Solution

A method, similar to `assignEntity`, is added to the `Schema` `options`, or to the `options` passed to `normalize`. When an entity is visited by `visitObject`, after it has completed the `assignEntity` procedure it will call `assignEntityCompleted` with the `normalized` object reference. This opens up the opportunity to apply any finishing touches to the entity.



```js
assignEntityCompleted: function (obj) {
  obj.hash = hashingFn(obj.a, obj.b, obj.c, obj.d);
}
```