### PR TITLE
return class instance from Schema.define

### DIFF
--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -47,5 +47,6 @@ export default class EntitySchema {
         this[key] = nestedSchema[key];
       }
     }
+    return this;
   }
 }


### PR DESCRIPTION
After this change it will be possible to write the following:

```js
const post = new Schema('posts').define({
    comments: arrayOf(comment)
});
```

It is better to read when you have a lot of shemas definition and don't have so much overhead that was in #46.

This is not intended to merge as is, this more a question why it wasn't done in first place.