### PR TITLE
add defaults typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,7 @@ export type SchemaOptions = {
   idAttribute?: string | ExtractAttribute;
   meta?: any;
   assignEntity?: AssignEntity;
+  defaults?: any;
 }
 
 export type IterableSchemaOptions = {
@@ -40,6 +41,7 @@ export class Schema {
   getKey(): string;
   getIdAttribute(): string;
   getMeta(prop: string): any;
+  getDefaults(): any;
 }
 
 export class IterableSchema {


### PR DESCRIPTION
# Problem

defaults attribute is not preset in SchemaOptions type

**Input**

```js
new Schema('data', {
    idAttribute: 'ID',
    defaults : { defaultValue: 1 }
});
```
**Output**

I'm getting following error from TypeScript
`Object literal may only specify known properties, and 'defaults' does not exist in type ...`

**Solution** 

Add `defaults?:any` to type script definition file on SchemaOptions type:
```js
export type SchemaOptions = {
  idAttribute?: string | ExtractAttribute;
  meta?: any;
  assignEntity?: AssignEntity;
  defaults?: any;
}
```

also add `getDefaults(): any;` to Schema class.