### PR TITLE
Update EntitySchema's define method

### DIFF
--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -36,7 +36,7 @@ export default class EntitySchema {
     }
     return this._meta && this._meta[prop];
   }
-  
+
   getDefaults() {
     return this._defaults;
   }
@@ -47,5 +47,7 @@ export default class EntitySchema {
         this[key] = nestedSchema[key];
       }
     }
+
+    return this;
   }
 }


### PR DESCRIPTION
# Problem

The problem is that we cannot easily create schemas by one-liner:
```js
const postSchema = new Schema('posts').define({user: userSchema});
```
It is not a big deal, really, but a tasty feature :icecream:.

# Solution
Simply return `this` from `EntitySchema` `define` method.