### PR TITLE
Pass parent object to idAttribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ const article = new Schema('articles');
 const article = new Schema('articles', { idAttribute: 'slug' });
 
 // Or you can specify a function to infer it
-function generateSlug(entity) { /* ... */ }
+function generateSlug(entity, parent) { /* ... */ }
 const article = new Schema('articles', { idAttribute: generateSlug });
 
 // You can also specify meta properties to be used for customizing the output in assignEntity (see below)

--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -22,8 +22,8 @@ export default class EntitySchema {
     return this._key;
   }
 
-  getId(entity) {
-    return this._getId(entity);
+  getId(entity, parent) {
+    return this._getId(entity, parent);
   }
 
   getIdAttribute() {

--- a/test/index.js
+++ b/test/index.js
@@ -655,6 +655,38 @@ describe('normalizr', function () {
     });
   });
 
+  it('can normalize single entity with custom id attribute function and parent data', function () {
+    function makeSlug(meta, article) {
+      return article.id + meta.foo;
+    }
+    
+    var meta = new Schema('meta', { idAttribute: makeSlug });
+    var input = [{
+      id: 1,
+      title: 'Some Article',
+      meta: { foo: 'bar' }
+    }, {
+      id: 2,
+      title: 'Other Article',
+      meta: { foo: 'bar' }
+    }];
+
+    Object.freeze(input);
+
+    normalize(input, arrayOf({ meta: meta})).should.eql({
+      entities: { 
+        meta: { 
+          '1bar': { foo: 'bar' }, 
+          '2bar': { foo: 'bar' } 
+        } 
+      },
+      result: [ 
+        { id: 1, title: 'Some Article', meta: '1bar' },
+        { id: 2, title: 'Other Article', meta: '2bar' } 
+      ] 
+    });
+  });
+
   it('can normalize an array', function () {
     var article = new Schema('articles'),
         input;


### PR DESCRIPTION
# Problem

Provide a mechanism to use a parent object data in generating entity id.
# Solution

Pass the `last` object through all of the traversal methods and make sure it gets passed specifically to `visitEntity` as that is where `getId` is called and pass the parent object into that function. 

Closes #160
