### PR TITLE
Added schema option for assigning the parent id on the child entity

### DIFF
--- a/src/EntitySchema.js
+++ b/src/EntitySchema.js
@@ -6,6 +6,7 @@ export default class EntitySchema {
 
     this._key = key;
     this._assignEntity = options.assignEntity;
+    this._assignParentId = options.assignParentId;
 
     const idAttribute = options.idAttribute || 'id';
     this._getId = typeof idAttribute === 'function' ? idAttribute : x => x[idAttribute];
@@ -16,6 +17,10 @@ export default class EntitySchema {
 
   getAssignEntity() {
     return this._assignEntity;
+  }
+
+  getAssignParentId() {
+    return this._assignParentId;
   }
 
   getKey() {

--- a/test/index.js
+++ b/test/index.js
@@ -1950,4 +1950,88 @@ describe('normalizr', function () {
     }).should.throw();
   });
 
+  it('can assign parent id on child entity', function () {
+    var article = new Schema('articles'),
+      comment = new Schema('comments', { assignParentId: true }),
+      input;
+
+    article.define({
+      comments: arrayOf(comment),
+    });
+
+    input = [{
+      id: 1,
+      title: 'Some Article',
+      comments: [{
+        id: 109,
+        content: 'Hai'
+      }]
+    }, {
+      id: 2,
+      title: 'Other Article',
+      comments: [{
+        id: 110,
+        content: 'Gee'
+      }]
+    }];
+
+    normalize(input, arrayOf(article)).should.eql({
+      result: [1, 2],
+      entities: {
+        articles: {
+          1: {
+            id: 1,
+            title: 'Some Article',
+            comments: [109]
+          },
+          2: {
+            id: 2,
+            title: 'Other Article',
+            comments: [110]
+          }
+        },
+        comments: {
+          109: {
+            id: 109,
+            content: 'Hai',
+            articles: 1,
+          },
+          110: {
+            id: 110,
+            content: 'Gee',
+            articles: 2,
+          }
+        }
+      }
+    });
+  });
+
+  it('can normalize parentless entities even when assignParentId is truthy', function () {
+    var comment = new Schema('comments', { assignParentId: true }),
+      input;
+
+    input = [{
+        id: 109,
+        content: 'Hai',
+      }
+    , { id: 110,
+        content: 'Gee',
+    }];
+
+    normalize(input, arrayOf(comment)).should.eql({
+      result: [109, 110],
+      entities: {
+        comments: {
+          109: {
+            id: 109,
+            content: 'Hai',
+          },
+          110: {
+            id: 110,
+            content: 'Gee',
+          }
+        }
+      }
+    });
+  });
 });


### PR DESCRIPTION
# Problem

Closes #172. Partially inspired by #135. 

Basically, we sometimes when normalizing, we would like to set the parent id on the child as well as setting the child ids on the parent. 

Example;

```
// INPUT 

[{
  id: 1,
  title: 'Some Article',
  comment: {
    id: 109,
    content: 'Hai'
  }
}, {
  id: 2,
  title: 'Other Article',
  comment: {
    id: 110,
    content: 'Gee'
  }
}]

// OUTPUT

{
  result: [1, 2],
  entities: {
    articles: {
      1: {
        id: 1,
        title: 'Some Article',
        comments: [109]
      },
      2: {
        id: 2,
        title: 'Other Article',
        comments: [110]
      }
    },
    comments: {
      109: {
        id: 109,
        content: 'Hai'
        article: 1,
      },
      110: {
        id: 110,
        content: 'Gee'
        article: 2,
      }
    }
  }
}
```

# Solution

When defining the schema, you can set assignParentId to true and this will result in the child entity getting the parent object's id set. 

# TODO
- [ ] Didn't cover the UnionSchema case. Let me know if that is a requirement to proceed. 
- [x] Add & Update Tests

