### PR TITLE
Update typings path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "description": "Normalizes JSON according to schema for Redux and Flux applications",
   "main": "lib/index.js",
-  "typings": "index.d.ts",
+  "typings": "lib/index.d.ts",
   "repository": {
     "url": "https://github.com/paularmstrong/normalizr.git",
     "type": "git"


### PR DESCRIPTION
# Problem

TypeScript complains that it can't find the types for the module (if `noImplicitAny` is on).

# Solution

Looks like the problem was introduced with [this commit](https://github.com/paularmstrong/normalizr/commit/c658c790e92e82fad09becaa00e9eef988c31b54#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L20) which removed the top level `index.d.ts` from the npm package but didn't update package.json to point to the one in `lib`. TypeScript definition test still passed because the root `index.d.ts` is present in the repo but excluded from the published package.