### PR TITLE
Point typings to correct path

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "description": "Normalizes JSON according to schema for Redux and Flux applications",
   "main": "lib/index.js",
-  "typings": "index.d.ts",
+  "typings": "lib/index.d.ts",
   "repository": {
     "url": "https://github.com/paularmstrong/normalizr.git",
     "type": "git"


### PR DESCRIPTION
# Problem

After installing `normalizr`, the `index.d.ts` seems to end up in the `lib` folder. The `typings` attribute in `package.json` points to `index.d.ts` instead of `lib/index.d.ts`, so the TypeScript compiler is not able to find it.

# Solution

Point to the correct path.

# TODO

*Fill in the following:*

- [ ] Add & Update Tests
