### PR TITLE
fix(index.d.ts): SchemaFunction return updated to any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare namespace schema {
-  export type SchemaFunction = (value: any, parent: any, key: string) => string
+  export type SchemaFunction = (value: any, parent: any, key: string) => any
   export type MergeFunction = (entityA: any, entityB: any) => any
 
   export class Array {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 declare namespace schema {
-  export type SchemaFunction = (value: any, parent: any, key: string) => any
-  export type MergeFunction = (entityA: any, entityB: any) => any
+  export type StrategyFunction = (value: any, parent: any, key: string) => any;
+  export type SchemaFunction = (value: any, parent: any, key: string) => string;
+  export type MergeFunction = (entityA: any, entityB: any) => any;
 
   export class Array {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
@@ -10,7 +11,7 @@ declare namespace schema {
   export interface EntityOptions {
     idAttribute?: string | SchemaFunction
     mergeStrategy?: MergeFunction
-    processStrategy?: SchemaFunction
+    processStrategy?: StrategyFunction
   }
 
   export class Entity {

--- a/src/__tests__/typescript/entity.ts
+++ b/src/__tests__/typescript/entity.ts
@@ -1,9 +1,21 @@
 import { normalize, schema } from '../../../index';
 
-const data = {/*...*/};
+type User = {
+  id_str: string,
+  name: string
+};
+
+type Tweet = {
+  id_str: string,
+  url: string,
+  user: User
+};
+
+
+const data = { /*...*/ };
 const user = new schema.Entity('users', {}, { idAttribute: 'id_str' });
 const tweet = new schema.Entity('tweets', { user: user }, {
-    idAttribute: 'id_str',
+  idAttribute: 'id_str',
     // Apply everything from entityB over entityA, except for "favorites"
     mergeStrategy: (entityA, entityB) => ({
       ...entityA,
@@ -11,7 +23,7 @@ const tweet = new schema.Entity('tweets', { user: user }, {
       favorites: entityA.favorites
     }),
     // Remove the URL field from the entity
-    processStrategy: (entity) => {
+    processStrategy: (entity: Tweet, parent, key) => {
       const {url, ...entityWithoutUrl} = entity;
       return entityWithoutUrl;
     }


### PR DESCRIPTION
Fixes #204.

<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

According to the documentation the processStrategy method should return an object.

processStrategy(value, parent, key): Strategy to use when pre-processing the entity. Use this method to add extra data, defaults, and/or completely change the entity before normalization is complete. Defaults to returning a shallow copy of the input entity.

But in the index.d.ts the processStartegy is defined as a SchemaFunction which is a function that returns string.

Also in the relationship example, processStrategy returns an object.

When I try to use normalizr in Typescript, the processStrategy is expecting to return a string instead of a object.

# Solution

Update the index.d.ts to change the SchemaFunction return from sting to any.
