### PR TITLE
Retain items in polymorphic mappings without defined schema

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -76,7 +76,11 @@ const normalizedData = normalize(data, userListSchema);
 }
 ```
 
-If your input data is an array of more than one type of entity, it is necessary to define a schema mapping. For example:
+If your input data is an array of more than one type of entity, it is necessary to define a schema mapping. 
+
+*Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created.*
+
+For example:
 
 ```js
 const data = [ { id: 1, type: 'admin' }, { id: 2, type: 'user' } ];
@@ -217,6 +221,8 @@ Can be a string or a function. If given a function, accepts the following argume
 
 #### Usage
 
+*Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created.*
+
 ```js
 const data = { owner: { id: 1, type: 'user', name: 'Anne' } };
 
@@ -275,5 +281,42 @@ const normalizedData = normalize(data, valuesSchema);
     items: { '1': { id: 1 }, '2': { id: 2 } }
   },
   result: { firstThing: 1, secondThing: 2 }
+}
+```
+
+If your input data is an object that has values of more than one type of entity, but their schema is not easily defined by the key, you can use a mapping of schema, much like `schema.Union` and `schema.Array`.
+
+*Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created.*
+
+For example:
+
+```js
+const data = {
+  '1': { id: 1, type: 'admin' }, 
+  '2': { id: 2, type: 'user' }
+};
+
+const userSchema = new schema.Entity('users');
+const adminSchema = new schema.Entity('admins');
+const valuesSchema = new schema.Values({
+  admins: adminSchema,
+  users: userSchema
+}, (input, parent, key) => `${input.type}s`);
+
+const normalizedData = normalize(data, valuesSchema);
+```
+
+#### Output
+
+```js
+{
+  entities: {
+    admins: { '1': { id: 1, type: 'admin' } },
+    users: { '2': { id: 2, type: 'user' } }
+  },
+  result: [
+    { id: 1, schema: 'admins' },
+    { id: 2, schema: 'users' }
+  ]
 }
 ```

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -26,15 +26,14 @@ export default class PolymorphicSchema {
     }
 
     const attr = this.getSchemaAttribute(input, parent, key);
-    const schema = this.schema[attr];
-    if (!schema) {
-      throw new Error(`No schema found for attribute "${attr}".`);
-    }
-    return schema;
+    return this.schema[attr];
   }
 
   normalizeValue(value, parent, key, visit, addEntity) {
     const schema = this.inferSchema(value, parent, key);
+    if (!schema) {
+      return value;
+    }
     const normalizedValue = visit(value, parent, key, schema, addEntity);
     return this.isSingleSchema || normalizedValue === undefined || normalizedValue === null ?
       normalizedValue :

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -47,14 +47,13 @@ describe(schema.Array.name, () => {
       const peopleSchema = new schema.Entity('person');
       const listSchema = new schema.Array({
         cats: catSchema,
-        dogs: {},
         people: peopleSchema
       }, inferSchemaFn);
 
       expect(normalize([
         { type: 'cats', id: '123' },
         { type: 'people', id: '123' },
-        { id: '789' },
+        { id: '789', name: 'fido' },
         { type: 'cats', id: '456' }
       ], listSchema)).toMatchSnapshot();
       expect(inferSchemaFn.mock.calls).toMatchSnapshot();

--- a/src/schemas/__tests__/Union.test.js
+++ b/src/schemas/__tests__/Union.test.js
@@ -24,9 +24,10 @@ describe(schema.Union.name, () => {
     const union = new schema.Union({
       users: user,
       groups: group
-    }, (input) => { return input.username ? 'users' : 'groups'; });
+    }, (input) => { return input.username ? 'users' : input.groupname ? 'groups' : null; });
 
     expect(normalize({ id: 1, username: 'Janey' }, union)).toMatchSnapshot();
     expect(normalize({ id: 2, groupname: 'People' }, union)).toMatchSnapshot();
+    expect(normalize({ id: 3, notdefined: 'yep' }, union)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Values.test.js
+++ b/src/schemas/__tests__/Values.test.js
@@ -26,17 +26,9 @@ describe(schema.Values.name, () => {
 
     expect(normalize({
       fido: { id: 1, type: 'dog' },
-      fluffy: { id: 1, type: 'cat' }
+      fluffy: { id: 1, type: 'cat' },
+      jim: { id: 2, type: 'lizard' }
     }, valuesSchema)).toMatchSnapshot();
-  });
-
-  it('throws if cannot find a matching schema', () => {
-    const dog = new schema.Entity('dogs');
-    const valuesSchema = new schema.Values({
-      dogs: dog
-    }, (entity) => `${entity.type}s`);
-
-    expect(() => normalize({ fluffy: { id: 1, type: 'cat' } }, valuesSchema)).toThrow();
   });
 
   it('filters out null and undefined values', () => {

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -81,10 +81,8 @@ Object {
       "schema": "people",
     },
     Object {
-      "id": Object {
-        "id": "789",
-      },
-      "schema": "dogs",
+      "id": "789",
+      "name": "fido",
     },
     Object {
       "id": "456",
@@ -112,6 +110,7 @@ Array [
       },
       Object {
         "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",
@@ -136,30 +135,7 @@ Array [
       },
       Object {
         "id": "789",
-      },
-      Object {
-        "id": "456",
-        "type": "cats",
-      },
-    ],
-    null,
-  ],
-  Array [
-    Object {
-      "id": "123",
-      "type": "people",
-    },
-    Array [
-      Object {
-        "id": "123",
-        "type": "cats",
-      },
-      Object {
-        "id": "123",
-        "type": "people",
-      },
-      Object {
-        "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",
@@ -184,6 +160,7 @@ Array [
       },
       Object {
         "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",
@@ -194,7 +171,8 @@ Array [
   ],
   Array [
     Object {
-      "id": "789",
+      "id": "123",
+      "type": "people",
     },
     Array [
       Object {
@@ -207,6 +185,7 @@ Array [
       },
       Object {
         "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",
@@ -218,6 +197,7 @@ Array [
   Array [
     Object {
       "id": "789",
+      "name": "fido",
     },
     Array [
       Object {
@@ -230,6 +210,7 @@ Array [
       },
       Object {
         "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",
@@ -254,6 +235,7 @@ Array [
       },
       Object {
         "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",
@@ -278,6 +260,7 @@ Array [
       },
       Object {
         "id": "789",
+        "name": "fido",
       },
       Object {
         "id": "456",

--- a/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -32,6 +32,16 @@ Object {
 }
 `;
 
+exports[`UnionSchema normalizes an array of multiple entities using a function to infer the schemaAttribute 3`] = `
+Object {
+  "entities": Object {},
+  "result": Object {
+    "id": 3,
+    "notdefined": "yep",
+  },
+}
+`;
+
 exports[`UnionSchema normalizes an object using string schemaAttribute 1`] = `
 Object {
   "entities": Object {

--- a/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -23,6 +23,10 @@ Object {
       "id": 1,
       "schema": "cats",
     },
+    "jim": Object {
+      "id": 2,
+      "type": "lizard",
+    },
   },
 }
 `;


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Polymorphic mappings (Array, Union, Values) require strict schema definitions. This means that if your API returns something you didn't expect, Normalizr will throw an error.

# Solution

Make it not strict and just retain the original input value in the result.

Fixes #207 

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
