### PR TITLE
replace file name from 'index' to 'normalizr' in dist folder to keep …

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import filesize from 'rollup-plugin-filesize';
 import uglify from 'rollup-plugin-uglify';
 
 const isProduction = process.env.NODE_ENV === 'production';
-const dest = `dist/index${isProduction ? '.min' : ''}.js`;
+const dest = `dist/normalizr${isProduction ? '.min' : ''}.js`;
 
 export default {
   entry: 'src/index.js',


### PR DESCRIPTION
…consistency with older version

<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

It's irregular to name your dist files as 'index.js'.

