### PR TITLE
Add denormalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Normalizr is a small, but powerful utility for taking JSON with a schema definit
 * [Introduction](/docs/introduction.md)
 * [Quick Start](/docs/quickstart.md)
 * [API](/docs/api.md)
-    - [normalize](/docs/api.md#normalize)
+    - [normalize](/docs/api.md#normalizedata-schema)
+    - [denormalize](/docs/api.md#denormalizeinput-schema-entities)
     - [schema](/docs/api.md#schema)
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Normalizr is a small, but powerful utility for taking JSON with a schema definit
 
 * [Normalizing GitHub Issues](/examples/github)
 * [Relational Data](/examples/relationships)
-* [Redux](/examples/redux)
+* [Interactive Redux](/examples/redux)
 
 ## Quick Start
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@
 * [Introduction](/docs/introduction.md)
 * [Quick Start](/docs/quickstart.md)
 * [API](/docs/api.md)
-    - [normalize](/docs/api.md#normalize)
+    - [normalize](/docs/api.md#normalizedata-schema)
+    - [denormalize](/docs/api.md#denormalizeinput-schema-entities)
     - [schema](/docs/api.md#schema)
 * [Frequently Asked Questions](/docs/faqs.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,7 @@
 # API
 
 * [normalize](#normalizedata-schema)
+* [denormalize](#denormalizeinput-schema-entities)
 * [schema](#schema)
   - [Array](#arraydefinition-schemaattribute)
   - [Entity](#entitykey-definition---options--)
@@ -24,6 +25,52 @@ const myData = { users: [ { id: 1 }, { id: 2 } ] };
 const user = new schema.Entity('users');
 const mySchema = { users: [ user ] }
 const normalizedData = normalize(myData, mySchema);
+```
+
+### Output
+
+```js
+{
+  result: { users: [ 1, 2 ] },
+  entities: {
+    users: {
+      '1': { id: 1 },
+      '2': { id: 2 }
+    }
+  }
+}
+```
+
+## `denormalize(input, schema, entities)`
+
+Denormalizes an input based on schema and provided entities. The reverse of `normalize`.
+
+*Special Note:* Be careful with denormalization. Prematurely reverting your data to large, nested objects could cause performance impacts in React (and other) applications.
+
+* `input`: **required** The normalized result that should be *de-normalized*. Usually the same value that was given in the `result` key of the output of `normalize`.
+* `schema`: **required** A schema definition that was used to get the value for `input`.
+* `entities`: **required** An object, keyed by entity schema names that may appear in the denormalized output.
+
+### Usage
+
+```js
+import { denormalize, schema } from 'normalizr';
+
+const user = new schema.Entity('users');
+const mySchema = { users: [ user ] }
+const entities = { users: { '1': { id: 1 }, '2': { id: 2 } } };
+const denormalizedData = denormalize({ users: [ 1, 2 ] }, mySchema, entities);
+```
+
+### Output
+
+```js
+{ 
+  users: [
+    { id: 1 },
+    { id: 2 }
+  ]
+}
 ```
 
 ## `schema`

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -1,11 +1,3 @@
 # Frequently Asked Questions
 
 If you are having trouble with Normalizr, try [StackOverflow](http://stackoverflow.com/questions/tagged/normalizr). There is a larger community there that will help you solve issues a lot quicker than opening an Issue on the Normalizr GitHub page.
-
-## How do I *denormalize* entities?
-
-This is entirely up to you. Normalizr does not include any logic to reverse the normalization because this process will be very heavily dependent on how and with what you store your data.
-
-## Will you accept a Pull Request that adds a *denormalize* function?
-
-Probably not. Unless you can show that it's flexible enough to work with everyone's data in every system, be it Redux, Flux, MobX, and anything else, it's just not going to be useful enough to justify the additional bloat to Normalizr.

--- a/examples/redux/index.js
+++ b/examples/redux/index.js
@@ -1,6 +1,7 @@
 import inquirer from 'inquirer';
 import store from './src/redux';
 import * as Action from './src/redux/actions';
+import * as Selector from './src/redux/selectors';
 
 const REPO = 'paularmstrong/normalizr';
 
@@ -89,6 +90,7 @@ const browse = (stateKey) => {
         { value: 'keys', name: 'List All Keys' },
         { value: 'view', name: 'View by Key' },
         { value: 'all', name: 'View All' },
+        { value: 'denormalize', name: 'Denormalize' },
         new inquirer.Separator(),
         { value: 'browseMain', name: 'Go Back to Browse Menu' },
         { value: 'main', name: 'Go Back to Main Menu' }
@@ -116,12 +118,42 @@ const browse = (stateKey) => {
       case 'all':
         console.log(JSON.stringify(state, null, 2));
         return browse(stateKey);
+      case 'denormalize':
+        return browseDenormalized(stateKey);
       case 'browseMain':
         return browseMain();
       case 'main':
         return main();
       default:
         return browse(stateKey);
+    }
+  });
+};
+
+const browseDenormalized = (stateKey) => {
+  return inquirer.prompt([
+    {
+      type: 'list',
+      name: 'selector',
+      message: `Denormalize a/and ${stateKey} entity`,
+      choices: [
+        ...Object.keys(store.getState()[stateKey]),
+        new inquirer.Separator(),
+        { value: 'browse', name: 'Go Back to Browse Menu' },
+        { value: 'main', name: 'Go Back to Main Menu' }
+      ]
+    }
+  ]).then(({ selector }) => {
+    switch (selector) {
+      case 'browse':
+        return browse(stateKey);
+      case 'main':
+        return main();
+      default: {
+        const data = Selector[`select${stateKey.replace(/s$/, '')}`](store.getState(), selector);
+        console.log(JSON.stringify(data, null, 2));
+        return browseDenormalized(stateKey);
+      }
     }
   });
 };

--- a/examples/redux/src/redux/modules/commits.js
+++ b/examples/redux/src/redux/modules/commits.js
@@ -1,5 +1,6 @@
 import * as Repo from './repos';
-import { normalize } from '../../../../../src';
+import { commit } from '../../api/schema';
+import { denormalize, normalize } from '../../../../../src';
 import { ADD_ENTITIES, addEntities } from '../actions';
 
 export const STATE_KEY = 'commits';
@@ -32,3 +33,5 @@ export const getCommits = ({ page = 0 } = {}) => (dispatch, getState, { api, sch
     console.error(error);
   });
 };
+
+export const selectHydrated = (state, id) => denormalize(id, commit, state);

--- a/examples/redux/src/redux/modules/issues.js
+++ b/examples/redux/src/redux/modules/issues.js
@@ -1,5 +1,6 @@
 import * as Repo from './repos';
-import { normalize } from '../../../../../src';
+import { issue } from '../../api/schema';
+import { denormalize, normalize } from '../../../../../src';
 import { ADD_ENTITIES, addEntities } from '../actions';
 
 export const STATE_KEY = 'issues';
@@ -32,3 +33,5 @@ export const getIssues = ({ page = 0 } = {}) => (dispatch, getState, { api, sche
     console.error(error);
   });
 };
+
+export const selectHydrated = (state, id) => denormalize(id, issue, state);

--- a/examples/redux/src/redux/modules/labels.js
+++ b/examples/redux/src/redux/modules/labels.js
@@ -1,5 +1,6 @@
 import * as Repo from './repos';
-import { normalize } from '../../../../../src';
+import { label } from '../../api/schema';
+import { denormalize, normalize } from '../../../../../src';
 import { ADD_ENTITIES, addEntities } from '../actions';
 
 export const STATE_KEY = 'labels';
@@ -32,3 +33,5 @@ export const getLabels = ({ page = 0 } = {}) => (dispatch, getState, { api, sche
     console.error(error);
   });
 };
+
+export const selectHydrated = (state, id) => denormalize(id, label, state);

--- a/examples/redux/src/redux/modules/milestones.js
+++ b/examples/redux/src/redux/modules/milestones.js
@@ -1,5 +1,6 @@
 import * as Repo from './repos';
-import { normalize } from '../../../../../src';
+import { milestone } from '../../api/schema';
+import { denormalize, normalize } from '../../../../../src';
 import { ADD_ENTITIES, addEntities } from '../actions';
 
 export const STATE_KEY = 'milestones';
@@ -32,3 +33,5 @@ export const getMilestones = ({ page = 0 } = {}) => (dispatch, getState, { api, 
     console.error(error);
   });
 };
+
+export const selectHydrated = (state, id) => denormalize(id, milestone, state);

--- a/examples/redux/src/redux/modules/pull-requests.js
+++ b/examples/redux/src/redux/modules/pull-requests.js
@@ -1,5 +1,6 @@
 import * as Repo from './repos';
-import { normalize } from '../../../../../src';
+import { denormalize, normalize } from '../../../../../src';
+import { pullRequest } from '../../api/schema';
 import { ADD_ENTITIES, addEntities } from '../actions';
 
 export const STATE_KEY = 'pullRequests';
@@ -32,3 +33,5 @@ export const getPullRequests = ({ page = 0 } = {}) => (dispatch, getState, { api
     console.error(error);
   });
 };
+
+export const selectHydrated = (state, id) => denormalize(id, pullRequest, state);

--- a/examples/redux/src/redux/modules/users.js
+++ b/examples/redux/src/redux/modules/users.js
@@ -1,4 +1,6 @@
 import { ADD_ENTITIES } from '../actions';
+import { denormalize } from '../../../../../src';
+import { user } from '../../api/schema';
 
 export const STATE_KEY = 'users';
 
@@ -19,3 +21,5 @@ export default function reducer(state = {}, action) {
       return state;
   }
 }
+
+export const selectHydrated = (state, id) => denormalize(id, user, state);

--- a/examples/redux/src/redux/selectors.js
+++ b/examples/redux/src/redux/selectors.js
@@ -1,0 +1,5 @@
+export { selectHydrated as selectcommit } from './modules/commits';
+export { selectHydrated as selectissue } from './modules/issues';
+export { selectHydrated as selectlabel } from './modules/labels';
+export { selectHydrated as selectmilestone } from './modules/milestones';
+export { selectHydrated as selectpullRequest } from './modules/pull-requests';

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,3 +56,9 @@ export function normalize(
   entities: any,
   result: any
 };
+
+export function denormalize(
+  input: any,
+  schema: Schema,
+  entities: any
+): any;

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,3 +1,38 @@
+exports[`denormalize denormalizes entities 1`] = `
+Array [
+  Object {
+    "id": 1,
+    "type": "foo",
+  },
+  Object {
+    "id": 2,
+    "type": "bar",
+  },
+]
+`;
+
+exports[`denormalize denormalizes nested entities 1`] = `
+Object {
+  "author": Object {
+    "id": "8472",
+    "name": "Paul",
+  },
+  "body": "This article is great.",
+  "comments": Array [
+    Object {
+      "comment": "I like it!",
+      "id": "comment-123-4738",
+      "user": Object {
+        "id": "10293",
+        "name": "Jane",
+      },
+    },
+  ],
+  "id": "123",
+  "title": "A Great Article",
+}
+`;
+
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -123,7 +123,6 @@ describe('normalize', () => {
   });
 });
 
-
 describe('denormalize', () => {
   it('cannot denormalize without a schema', () => {
     expect(() => denormalize({})).toThrow();

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -129,6 +129,10 @@ describe('denormalize', () => {
     expect(() => denormalize({})).toThrow();
   });
 
+  it('returns the input if falsy', () => {
+    expect(denormalize(false, {}, {})).toBe(false);
+  });
+
   it('denormalizes entities', () => {
     const mySchema = new schema.Entity('tacos');
     const entities = {

--- a/src/__tests__/typescript/array.ts
+++ b/src/__tests__/typescript/array.ts
@@ -1,4 +1,4 @@
-import { normalize, schema } from '../../../index';
+import { denormalize, normalize, schema } from '../../../index';
 
 const data = [ { id: '123', name: 'Jim' }, { id: '456', name: 'Jane' } ];
 const userSchema = new schema.Entity('users');
@@ -8,3 +8,5 @@ const normalizedData = normalize(data, userListSchema);
 
 const userListSchemaAlt = [ userSchema ];
 const normalizedDataAlt = normalize(data, userListSchemaAlt);
+
+const denormalizedData = denormalize(normalizedData.result, userListSchema, normalizedData.entities);

--- a/src/__tests__/typescript/array_schema.ts
+++ b/src/__tests__/typescript/array_schema.ts
@@ -1,4 +1,4 @@
-import { normalize, schema } from '../../../index';
+import { denormalize, normalize, schema } from '../../../index';
 
 const data = [ { id: 1, type: 'admin' }, { id: 2, type: 'user' } ];
 const userSchema = new schema.Entity('users');
@@ -10,3 +10,5 @@ const myArray = new schema.Array({
 }, (input, parent, key) => `${input.type}s`);
 
 const normalizedData = normalize(data, myArray);
+
+const denormalizedData = denormalize(normalizedData.result, myArray, normalizedData.entities);

--- a/src/__tests__/typescript/entity.ts
+++ b/src/__tests__/typescript/entity.ts
@@ -1,4 +1,4 @@
-import { normalize, schema } from '../../../index';
+import { denormalize, normalize, schema } from '../../../index';
 
 type User = {
   id_str: string,
@@ -30,3 +30,4 @@ const tweet = new schema.Entity('tweets', { user: user }, {
 });
 
 const normalizedData = normalize(data, tweet);
+const denormalizedData = denormalize(normalizedData.result, tweet, normalizedData.entities);

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -21,11 +21,20 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return values.map((value, index) => visit(value, parent, key, schema, addEntity));
 };
 
+export const denormalize = (schema, input, unvisit, entities) => {
+  schema = validateSchema(schema);
+  return input.map((entityOrId) => unvisit(entityOrId, schema, entities));
+};
+
 export default class ArraySchema extends PolymorphicSchema {
   normalize(input, parent, key, visit, addEntity) {
     const values = getValues(input);
 
     return values.map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity))
       .filter((value) => value !== undefined && value !== null);
+  }
+
+  denormalize(input, unvisit, entities) {
+    return input.map((value) => this.denormalizeValue(value, unvisit, entities));
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -50,4 +50,17 @@ export default class EntitySchema {
     addEntity(this, processedEntity, input, parent, key);
     return this.getId(input, parent, key);
   }
+
+  denormalize(entityOrId, unvisit, entities) {
+    const entity = typeof entityOrId === 'object' ? entityOrId : entities[this.key][entityOrId];
+    const entityCopy = { ...entity };
+    Object.keys(this.schema).forEach((key) => {
+      if (entityCopy.hasOwnProperty(key)) {
+        const schema = this.schema[key];
+        entityCopy[key] = unvisit(entityCopy[key], schema, entities);
+      }
+    });
+
+    return entityCopy;
+  }
 }

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -16,9 +16,8 @@ export const denormalize = (schema, input, unvisit, entities) => {
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     const localSchema = schema[key];
-    const value = unvisit(object[key], localSchema, entities);
-    if (value) {
-      object[key] = value;
+    if (object[key]) {
+      object[key] = unvisit(object[key], localSchema, entities);
     }
   });
   return object;

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -12,6 +12,18 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return object;
 };
 
+export const denormalize = (schema, input, unvisit, entities) => {
+  const object = { ...input };
+  Object.keys(schema).forEach((key) => {
+    const localSchema = schema[key];
+    const value = unvisit(object[key], localSchema, entities);
+    if (value) {
+      object[key] = value;
+    }
+  });
+  return object;
+};
+
 export default class ObjectSchema {
   constructor(definition) {
     this.define(definition);
@@ -26,5 +38,9 @@ export default class ObjectSchema {
 
   normalize(...args) {
     return normalize(this.schema, ...args);
+  }
+
+  denormalize(...args) {
+    return denormalize(this.schema, ...args);
   }
 }

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -42,7 +42,7 @@ export default class PolymorphicSchema {
 
   denormalizeValue(value, unvisit, entities) {
     if (!this.isSingleSchema && !value.schema) {
-      throw new Error(`Unable to denormalize polymorphic schema. No definition found for ${JSON.stringify(value)}`);
+      return value;
     }
     const schema = this.isSingleSchema ? this.schema : this.schema[value.schema];
     return unvisit(value.id || value, schema, entities);

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -39,4 +39,12 @@ export default class PolymorphicSchema {
       normalizedValue :
       { id: normalizedValue, schema: this.getSchemaAttribute(value, parent, key) };
   }
+
+  denormalizeValue(value, unvisit, entities) {
+    if (!this.isSingleSchema && !value.schema) {
+      throw new Error(`Unable to denormalize polymorphic schema. No definition found for ${JSON.stringify(value)}`);
+    }
+    const schema = this.isSingleSchema ? this.schema : this.schema[value.schema];
+    return unvisit(value.id || value, schema, entities);
+  }
 }

--- a/src/schemas/Union.js
+++ b/src/schemas/Union.js
@@ -11,4 +11,8 @@ export default class UnionSchema extends PolymorphicSchema {
   normalize(input, parent, key, visit, addEntity) {
     return this.normalizeValue(input, parent, key, visit, addEntity);
   }
+
+  denormalize(input, unvisit, entities) {
+    return this.denormalizeValue(input, unvisit, entities);
+  }
 }

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -10,4 +10,14 @@ export default class ValuesSchema extends PolymorphicSchema {
       } : output;
     }, {});
   }
+
+  denormalize(input, unvisit, entities) {
+    return Object.keys(input).reduce((output, key) => {
+      const entityOrId = input[key];
+      return {
+        ...output,
+        [key]: this.denormalizeValue(entityOrId, unvisit, entities)
+      };
+    }, {});
+  }
 }

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -109,4 +109,42 @@ describe(`${schema.Entity.name} denormalization`, () => {
     };
     expect(denormalize(1, mySchema, entities)).toMatchSnapshot();
   });
+
+  it('denormalizes deep entities', () => {
+    const foodSchema = new schema.Entity('foods');
+    const menuSchema = new schema.Entity('menus', {
+      food: foodSchema
+    });
+
+    const entities = {
+      menus: {
+        1: { id: 1, food: 1 },
+        2: { id: 2 }
+      },
+      foods: {
+        1: { id: 1 }
+      }
+    };
+
+    expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(2, menuSchema, entities)).toMatchSnapshot();
+  });
+
+  it('can denormalize already partially denormalized data', () => {
+    const foodSchema = new schema.Entity('foods');
+    const menuSchema = new schema.Entity('menus', {
+      food: foodSchema
+    });
+
+    const entities = {
+      menus: {
+        1: { id: 1, food: { id: 1 } }
+      },
+      foods: {
+        1: { id: 1 }
+      }
+    };
+
+    expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
+  });
 });

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-import { normalize, schema } from '../../';
+import { denormalize, normalize, schema } from '../../';
 
-describe(schema.Entity.name, () => {
+describe(`${schema.Entity.name} normalization`, () => {
   it('normalizes an entity', () => {
     const entity = new schema.Entity('item');
     expect(normalize({ id: 1 }, entity)).toMatchSnapshot();
@@ -96,5 +96,17 @@ describe(schema.Entity.name, () => {
 
       expect(normalize({ message: { id: '123', data: { attachment: { id: '456' } } } }, myEntity)).toMatchSnapshot();
     });
+  });
+});
+
+describe(`${schema.Entity.name} denormalization`, () => {
+  it('denormalizes an entity', () => {
+    const mySchema = new schema.Entity('tacos');
+    const entities = {
+      tacos: {
+        1: { id: 1, type: 'foo' }
+      }
+    };
+    expect(denormalize(1, mySchema, entities)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-import { normalize, schema } from '../../';
+import { denormalize, normalize, schema } from '../../';
 
-describe(schema.Object.name, () => {
+describe(`${schema.Object.name} normalization`, () => {
   it('normalizes an object', () => {
     const userSchema = new schema.Entity('user');
     const object = new schema.Object({
@@ -19,5 +19,30 @@ describe(schema.Object.name, () => {
     const userSchema = new schema.Entity('user');
     const users = { foo: userSchema, bar: userSchema, baz: userSchema };
     expect(normalize({ foo: {}, bar: { id: '1' } }, users)).toMatchSnapshot();
+  });
+});
+
+describe(`${schema.Object.name} denormalization`, () => {
+  it('denormalizes an object', () => {
+    const userSchema = new schema.Entity('user');
+    const object = new schema.Object({
+      user: userSchema
+    });
+    const entities = {
+      user: {
+        1: { id: 1, name: 'Nacho' }
+      }
+    };
+    expect(denormalize({ user: 1 }, object, entities)).toMatchSnapshot();
+  });
+
+  it('denormalizes plain object shorthand', () => {
+    const userSchema = new schema.Entity('user');
+    const entities = {
+      user: {
+        1: { id: 1, name: 'Jane' }
+      }
+    };
+    expect(denormalize({ user: 1 }, { user: userSchema }, entities)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -43,6 +43,6 @@ describe(`${schema.Object.name} denormalization`, () => {
         1: { id: 1, name: 'Jane' }
       }
     };
-    expect(denormalize({ user: 1 }, { user: userSchema }, entities)).toMatchSnapshot();
+    expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, entities)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Union.test.js
+++ b/src/schemas/__tests__/Union.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-import { normalize, schema } from '../../';
+import { denormalize, normalize, schema } from '../../';
 
-describe(schema.Union.name, () => {
+describe(`${schema.Union.name} normalization`, () => {
   it('throws if not given a schemaAttribute', () => {
     expect(() => new schema.Union({})).toThrow();
   });
@@ -29,5 +29,38 @@ describe(schema.Union.name, () => {
     expect(normalize({ id: 1, username: 'Janey' }, union)).toMatchSnapshot();
     expect(normalize({ id: 2, groupname: 'People' }, union)).toMatchSnapshot();
     expect(normalize({ id: 3, notdefined: 'yep' }, union)).toMatchSnapshot();
+  });
+});
+
+describe(`${schema.Union.name} denormalization`, () => {
+  const user = new schema.Entity('users');
+  const group = new schema.Entity('groups');
+  const entities = {
+    users: {
+      1: { id: 1, username: 'Janey', type: 'users' }
+    },
+    groups: {
+      2: { id: 2, groupname: 'People', type: 'groups' }
+    }
+  };
+
+  it('denormalizes an object using string schemaAttribute', () => {
+    const union = new schema.Union({
+      users: user,
+      groups: group
+    }, 'type');
+
+    expect(denormalize({ id: 1, schema: 'users' }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 2, schema: 'groups' }, union, entities)).toMatchSnapshot();
+  });
+
+  it('denormalizes an array of multiple entities using a function to infer the schemaAttribute', () => {
+    const union = new schema.Union({
+      users: user,
+      groups: group
+    }, (input) => { return input.username ? 'users' : 'groups'; });
+
+    expect(denormalize({ id: 1, schema: 'users' }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 2, schema: 'groups' }, union, entities)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Union.test.js
+++ b/src/schemas/__tests__/Union.test.js
@@ -63,4 +63,13 @@ describe(`${schema.Union.name} denormalization`, () => {
     expect(denormalize({ id: 1, schema: 'users' }, union, entities)).toMatchSnapshot();
     expect(denormalize({ id: 2, schema: 'groups' }, union, entities)).toMatchSnapshot();
   });
+
+  it('returns the original value no schema is given', () => {
+    const union = new schema.Union({
+      users: user,
+      groups: group
+    }, (input) => { return input.username ? 'users' : 'groups'; });
+
+    expect(denormalize({ id: 1 }, union, entities)).toMatchSnapshot();
+  });
 });

--- a/src/schemas/__tests__/Values.test.js
+++ b/src/schemas/__tests__/Values.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
-import { normalize, schema } from '../../';
+import { denormalize, normalize, schema } from '../../';
 
-describe(schema.Values.name, () => {
+describe(`${schema.Values.name} normalization`, () => {
   it('normalizes the values of an object with the given schema', () => {
     const cat = new schema.Entity('cats');
     const dog = new schema.Entity('dogs');
@@ -44,5 +44,26 @@ describe(schema.Values.name, () => {
       milo: null,
       fluffy: { id: 1, type: 'cats' }
     }, valuesSchema)).toMatchSnapshot();
+  });
+});
+
+describe(`${schema.Values.name} denormalization`, () => {
+  it('denormalizes the values of an object with the given schema', () => {
+    const cat = new schema.Entity('cats');
+    const dog = new schema.Entity('dogs');
+    const valuesSchema = new schema.Values({
+      dogs: dog,
+      cats: cat
+    }, (entity, key) => entity.type);
+
+    const entities = {
+      cats: { 1: { id: 1, type: 'cats' } },
+      dogs: { 1: { id: 1, type: 'dogs' } }
+    };
+
+    expect(denormalize({
+      fido: { id: 1, schema: 'dogs' },
+      fluffy: { id: 1, schema: 'cats' }
+    }, valuesSchema, entities)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -1,4 +1,50 @@
-exports[`ArraySchema Class filters out undefined and null normalized values 1`] = `
+exports[`ArraySchema denormalization Class denormalizes a single entity 1`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "Milo",
+  },
+  Object {
+    "id": 2,
+    "name": "Jake",
+  },
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes multiple entities 1`] = `
+Array [
+  Object {
+    "id": "123",
+    "type": "cats",
+  },
+  Object {
+    "id": "123",
+    "type": "people",
+  },
+  Object {
+    "id": "789",
+  },
+  Object {
+    "id": "456",
+    "type": "cats",
+  },
+]
+`;
+
+exports[`ArraySchema denormalization Object denormalizes a single entity 1`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "Milo",
+  },
+  Object {
+    "id": 2,
+    "name": "Jake",
+  },
+]
+`;
+
+exports[`ArraySchema normalization Class filters out undefined and null normalized values 1`] = `
 Object {
   "entities": Object {
     "user": Object {
@@ -13,7 +59,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema Class normalizes Objects using their values 1`] = `
+exports[`ArraySchema normalization Class normalizes Objects using their values 1`] = `
 Object {
   "entities": Object {
     "user": Object {
@@ -32,7 +78,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema Class normalizes a single entity 1`] = `
+exports[`ArraySchema normalization Class normalizes a single entity 1`] = `
 Object {
   "entities": Object {
     "cats": Object {
@@ -51,7 +97,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema Class normalizes multiple entities 1`] = `
+exports[`ArraySchema normalization Class normalizes multiple entities 1`] = `
 Object {
   "entities": Object {
     "cats": Object {
@@ -92,7 +138,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema Class normalizes multiple entities 2`] = `
+exports[`ArraySchema normalization Class normalizes multiple entities 2`] = `
 Array [
   Array [
     Object {
@@ -272,7 +318,7 @@ Array [
 ]
 `;
 
-exports[`ArraySchema Object normalizes Objects using their values 1`] = `
+exports[`ArraySchema normalization Object normalizes Objects using their values 1`] = `
 Object {
   "entities": Object {
     "user": Object {
@@ -291,7 +337,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema Object normalizes plain arrays as shorthand for ArraySchema 1`] = `
+exports[`ArraySchema normalization Object normalizes plain arrays as shorthand for ArraySchema 1`] = `
 Object {
   "entities": Object {
     "user": Object {
@@ -310,7 +356,7 @@ Object {
 }
 `;
 
-exports[`ArraySchema Object passes its parent to its children when normalizing 1`] = `
+exports[`ArraySchema normalization Object passes its parent to its children when normalizing 1`] = `
 Object {
   "entities": Object {
     "children": Object {

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -1,4 +1,11 @@
-exports[`EntitySchema idAttribute can build the entity's ID from the parent object 1`] = `
+exports[`EntitySchema denormalization denormalizes an entity 1`] = `
+Object {
+  "id": 1,
+  "type": "foo",
+}
+`;
+
+exports[`EntitySchema normalization idAttribute can build the entity's ID from the parent object 1`] = `
 Object {
   "entities": Object {
     "users": Object {
@@ -15,7 +22,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema idAttribute can normalize entity IDs based on their object key 1`] = `
+exports[`EntitySchema normalization idAttribute can normalize entity IDs based on their object key 1`] = `
 Object {
   "entities": Object {
     "users": Object {
@@ -40,7 +47,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema idAttribute can use a custom idAttribute string 1`] = `
+exports[`EntitySchema normalization idAttribute can use a custom idAttribute string 1`] = `
 Object {
   "entities": Object {
     "users": Object {
@@ -54,7 +61,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema mergeStrategy can use a custom merging strategy 1`] = `
+exports[`EntitySchema normalization mergeStrategy can use a custom merging strategy 1`] = `
 Object {
   "entities": Object {
     "tacos": Object {
@@ -72,7 +79,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema mergeStrategy defaults to plain merging 1`] = `
+exports[`EntitySchema normalization mergeStrategy defaults to plain merging 1`] = `
 Object {
   "entities": Object {
     "tacos": Object {
@@ -90,7 +97,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema normalizes an entity 1`] = `
+exports[`EntitySchema normalization normalizes an entity 1`] = `
 Object {
   "entities": Object {
     "item": Object {
@@ -103,7 +110,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema processStrategy can use a custom processing strategy 1`] = `
+exports[`EntitySchema normalization processStrategy can use a custom processing strategy 1`] = `
 Object {
   "entities": Object {
     "tacos": Object {
@@ -118,7 +125,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema processStrategy can use information from the parent in the process strategy 1`] = `
+exports[`EntitySchema normalization processStrategy can use information from the parent in the process strategy 1`] = `
 Object {
   "entities": Object {
     "children": Object {
@@ -141,7 +148,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema processStrategy is run before and passed to the schema normalization 1`] = `
+exports[`EntitySchema normalization processStrategy is run before and passed to the schema normalization 1`] = `
 Object {
   "entities": Object {
     "attachments": Object {

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -1,7 +1,31 @@
+exports[`EntitySchema denormalization can denormalize already partially denormalized data 1`] = `
+Object {
+  "food": Object {
+    "id": 1,
+  },
+  "id": 1,
+}
+`;
+
 exports[`EntitySchema denormalization denormalizes an entity 1`] = `
 Object {
   "id": 1,
   "type": "foo",
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities 1`] = `
+Object {
+  "food": Object {
+    "id": 1,
+  },
+  "id": 1,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities 2`] = `
+Object {
+  "id": 2,
 }
 `;
 

--- a/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -1,4 +1,22 @@
-exports[`ObjectSchema filters out undefined and null values 1`] = `
+exports[`ObjectSchema denormalization denormalizes an object 1`] = `
+Object {
+  "user": Object {
+    "id": 1,
+    "name": "Nacho",
+  },
+}
+`;
+
+exports[`ObjectSchema denormalization denormalizes plain object shorthand 1`] = `
+Object {
+  "user": Object {
+    "id": 1,
+    "name": "Jane",
+  },
+}
+`;
+
+exports[`ObjectSchema normalization filters out undefined and null values 1`] = `
 Object {
   "entities": Object {
     "user": Object {
@@ -14,7 +32,7 @@ Object {
 }
 `;
 
-exports[`ObjectSchema normalizes an object 1`] = `
+exports[`ObjectSchema normalization normalizes an object 1`] = `
 Object {
   "entities": Object {
     "user": Object {
@@ -29,7 +47,7 @@ Object {
 }
 `;
 
-exports[`ObjectSchema normalizes plain objects as shorthand for ObjectSchema 1`] = `
+exports[`ObjectSchema normalization normalizes plain objects as shorthand for ObjectSchema 1`] = `
 Object {
   "entities": Object {
     "user": Object {

--- a/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -30,6 +30,12 @@ Object {
 }
 `;
 
+exports[`UnionSchema denormalization returns the original value no schema is given 1`] = `
+Object {
+  "id": 1,
+}
+`;
+
 exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `
 Object {
   "entities": Object {

--- a/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -1,4 +1,36 @@
-exports[`UnionSchema normalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `
+exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `
+Object {
+  "id": 1,
+  "type": "users",
+  "username": "Janey",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 2`] = `
+Object {
+  "groupname": "People",
+  "id": 2,
+  "type": "groups",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 1`] = `
+Object {
+  "id": 1,
+  "type": "users",
+  "username": "Janey",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 2`] = `
+Object {
+  "groupname": "People",
+  "id": 2,
+  "type": "groups",
+}
+`;
+
+exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 1`] = `
 Object {
   "entities": Object {
     "users": Object {
@@ -15,7 +47,7 @@ Object {
 }
 `;
 
-exports[`UnionSchema normalizes an array of multiple entities using a function to infer the schemaAttribute 2`] = `
+exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 2`] = `
 Object {
   "entities": Object {
     "groups": Object {
@@ -32,7 +64,7 @@ Object {
 }
 `;
 
-exports[`UnionSchema normalizes an array of multiple entities using a function to infer the schemaAttribute 3`] = `
+exports[`UnionSchema normalization normalizes an array of multiple entities using a function to infer the schemaAttribute 3`] = `
 Object {
   "entities": Object {},
   "result": Object {
@@ -42,7 +74,7 @@ Object {
 }
 `;
 
-exports[`UnionSchema normalizes an object using string schemaAttribute 1`] = `
+exports[`UnionSchema normalization normalizes an object using string schemaAttribute 1`] = `
 Object {
   "entities": Object {
     "users": Object {
@@ -59,7 +91,7 @@ Object {
 }
 `;
 
-exports[`UnionSchema normalizes an object using string schemaAttribute 2`] = `
+exports[`UnionSchema normalization normalizes an object using string schemaAttribute 2`] = `
 Object {
   "entities": Object {
     "groups": Object {

--- a/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -1,4 +1,17 @@
-exports[`ValuesSchema can use a function to determine the schema when normalizing 1`] = `
+exports[`ValuesSchema denormalization denormalizes the values of an object with the given schema 1`] = `
+Object {
+  "fido": Object {
+    "id": 1,
+    "type": "dogs",
+  },
+  "fluffy": Object {
+    "id": 1,
+    "type": "cats",
+  },
+}
+`;
+
+exports[`ValuesSchema normalization can use a function to determine the schema when normalizing 1`] = `
 Object {
   "entities": Object {
     "cats": Object {
@@ -31,7 +44,7 @@ Object {
 }
 `;
 
-exports[`ValuesSchema filters out null and undefined values 1`] = `
+exports[`ValuesSchema normalization filters out null and undefined values 1`] = `
 Object {
   "entities": Object {
     "cats": Object {
@@ -50,7 +63,7 @@ Object {
 }
 `;
 
-exports[`ValuesSchema normalizes the values of an object with the given schema 1`] = `
+exports[`ValuesSchema normalization normalizes the values of an object with the given schema 1`] = `
 Object {
   "entities": Object {
     "cats": Object {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

The people have spoken. They want denormalization. Normalizr doesn't include a reverse of normalization internally. [External](https://github.com/gpbl/denormalizr) packages require you to add more dependencies and increase your application bloat.

# Solution

I wanted a solution that was open enough for everyone. Therefore, I didn't want to just assume any data structure. So, `denormalize` will expect two separate arguments for what was the `result` and `entities` from normalization: `denormalize(result, schema, entities)`.

This looks to be the simplest, fastest, and smallest approach to denormalization, to me.

# TODO

- [x] Add & update tests (100% test coverage)
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation

# Size Diff

## Before

```
  Package:      dist/index.js
  Bundle Size:  13.63 KB
  Compressed:   3.12 KB

  Package:      dist/index.min.js
  Bundle Size:  6.94 KB
  Compressed:   2.12 KB
```

## After

```
  Package:      dist/index.js
  Bundle Size:  16.68 KB
  Compressed:   3.52 KB

  Package:      dist/index.min.js
  Bundle Size:  8.45 KB
  Compressed:   2.39 KB
```
