### PR TITLE
Added recursive dependencies support for denormalize method

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -33,6 +33,21 @@ Object {
 }
 `;
 
+exports[`denormalize denormalizes recursive dependencies 1`] = `
+Object {
+  "title": "Weekly report",
+  "user": Object {
+    "reports": Array [
+      Object {
+        "title": "Weekly report",
+        "user": Object {},
+      },
+    ],
+    "role": "manager",
+  },
+}
+`;
+
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -35,21 +35,34 @@ Object {
 
 exports[`denormalize denormalizes recursive dependencies 1`] = `
 Object {
+  "id": 1,
   "title": "Weekly report",
   "user": Object {
+    "id": 1,
     "reports": Array [
+      1,
+    ],
+    "role": "manager",
+  },
+}
+`;
+
+exports[`denormalize denormalizes recursive dependencies with custom idAttribute 1`] = `
+Object {
+  "title": "Weekly report",
+  "user": Object {
+    "id": 1,
+    "reports": Array [
+      1,
       Object {
-        "title": "Weekly report",
-        "user": Object {
-          "reports": Array [
-            1,
-          ],
-          "role": "manager",
-        },
+        "title": "Monthly report",
+        "user": 1,
+        "uuid": 2,
       },
     ],
     "role": "manager",
   },
+  "uuid": 1,
 }
 `;
 

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -40,7 +40,12 @@ Object {
     "reports": Array [
       Object {
         "title": "Weekly report",
-        "user": Object {},
+        "user": Object {
+          "reports": Array [
+            1,
+          ],
+          "role": "manager",
+        },
       },
     ],
     "role": "manager",

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -221,22 +221,51 @@ describe('denormalize', () => {
     const entities = {
       reports: {
         1: {
+          id: 1,
           title: 'Weekly report',
           user: 1
-        },
-        2: {
-          title: 'Monthly report',
-          user: 2
         }
       },
       users: {
         1: {
+          id: 1,
           role: 'manager',
           reports: [ 1 ]
+        }
+      }
+    };
+    expect(denormalize('1', report, entities)).toMatchSnapshot();
+  });
+
+  it('denormalizes recursive dependencies with custom idAttribute', () => {
+    const user = new schema.Entity('users');
+    const report = new schema.Entity('reports', {}, { idAttribute: 'uuid' });
+
+    user.define({
+      reports: [ report ]
+    });
+    report.define({
+      user: user
+    });
+
+    const entities = {
+      reports: {
+        1: {
+          uuid: 1,
+          title: 'Weekly report',
+          user: 1
         },
         2: {
-          role: 'user',
-          reports: []
+          uuid: 2,
+          title: 'Monthly report',
+          user: 1
+        }
+      },
+      users: {
+        1: {
+          id: 1,
+          role: 'manager',
+          reports: [ 1, 2 ]
         }
       }
     };

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -206,4 +206,40 @@ describe('denormalize', () => {
     });
     expect(() => denormalize('123', article, entities)).not.toThrow();
   });
+
+  it('denormalizes recursive dependencies', () => {
+    const user = new schema.Entity('users');
+    const report = new schema.Entity('reports');
+
+    user.define({
+      reports: [ report ]
+    });
+    report.define({
+      user: user
+    });
+
+    const entities = {
+      reports: {
+        1: {
+          title: 'Weekly report',
+          user: 1
+        },
+        2: {
+          title: 'Monthly report',
+          user: 2
+        }
+      },
+      users: {
+        1: {
+          role: 'manager',
+          reports: [ 1 ]
+        },
+        2: {
+          role: 'user',
+          reports: []
+        }
+      }
+    };
+    expect(denormalize('1', report, entities)).toMatchSnapshot();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -55,16 +55,16 @@ export const normalize = (input, schema) => {
   return { entities, result };
 };
 
-const unvisit = (input, schema, entities) => {
-  if (typeof schema === 'object' && (!schema.normalize || typeof schema.normalize !== 'function')) {
+const unvisit = (input, schema, entities, visitedEntities) => {
+  if (typeof schema === 'object' && (!schema.denormalize || typeof schema.denormalize !== 'function')) {
     let method = ObjectUtils.denormalize;
     if (Array.isArray(schema)) {
       method = ArrayUtils.denormalize;
     }
-    return method(schema, input, unvisit, entities);
+    return method(schema, input, unvisit, entities, visitedEntities);
   }
 
-  return schema.denormalize(input, unvisit, entities);
+  return schema.denormalize(input, unvisit, entities, visitedEntities);
 };
 
 export const denormalize = (input, schema, entities) => {
@@ -72,6 +72,6 @@ export const denormalize = (input, schema, entities) => {
     return input;
   }
 
-  entities = { ...entities, __cache: {} };
-  return unvisit(input, schema, entities);
+  const visitedEntities = {};
+  return unvisit(input, schema, entities, visitedEntities);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -72,5 +72,6 @@ export const denormalize = (input, schema, entities) => {
     return input;
   }
 
+  entities = { ...entities, __cache: {} };
   return unvisit(input, schema, entities);
 };

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -21,9 +21,9 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return values.map((value, index) => visit(value, parent, key, schema, addEntity));
 };
 
-export const denormalize = (schema, input, unvisit, entities) => {
+export const denormalize = (schema, input, unvisit, entities, visitedEntities) => {
   schema = validateSchema(schema);
-  return input.map((entityOrId) => unvisit(entityOrId, schema, entities));
+  return input.map((entityOrId) => unvisit(entityOrId, schema, entities, visitedEntities));
 };
 
 export default class ArraySchema extends PolymorphicSchema {
@@ -34,7 +34,7 @@ export default class ArraySchema extends PolymorphicSchema {
       .filter((value) => value !== undefined && value !== null);
   }
 
-  denormalize(input, unvisit, entities) {
-    return input.map((value) => this.denormalizeValue(value, unvisit, entities));
+  denormalize(input, unvisit, entities, visitedEntities) {
+    return input.map((value) => this.denormalizeValue(value, unvisit, entities, visitedEntities));
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -53,8 +53,8 @@ export default class EntitySchema {
     return this.getId(input, parent, key);
   }
 
-  denormalize(entityOrId, unvisit, entities) {
+  denormalize(entityOrId, unvisit, entities, visitedEntities) {
     const entity = typeof entityOrId === 'object' ? entityOrId : entities[this.key][entityOrId];
-    return denormalize(this.schema, entity, unvisit, entities);
+    return denormalize(this.schema, entity, unvisit, entities, visitedEntities);
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -55,6 +55,17 @@ export default class EntitySchema {
 
   denormalize(entityOrId, unvisit, entities, visitedEntities) {
     const entity = typeof entityOrId === 'object' ? entityOrId : entities[this.key][entityOrId];
+
+    if (!visitedEntities[this.key]) {
+      visitedEntities[this.key] = {};
+    }
+
+    const id = this.getId(entity);
+    if (visitedEntities[this.key][id]) {
+      return id;
+    }
+    visitedEntities[this.key][id] = true;
+
     return denormalize(this.schema, entity, unvisit, entities, visitedEntities);
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -1,3 +1,5 @@
+import { denormalize } from './Object';
+
 export default class EntitySchema {
   constructor(key, definition = {}, options = {}) {
     if (!key || typeof key !== 'string') {
@@ -53,14 +55,6 @@ export default class EntitySchema {
 
   denormalize(entityOrId, unvisit, entities) {
     const entity = typeof entityOrId === 'object' ? entityOrId : entities[this.key][entityOrId];
-    const entityCopy = { ...entity };
-    Object.keys(this.schema).forEach((key) => {
-      if (entityCopy.hasOwnProperty(key)) {
-        const schema = this.schema[key];
-        entityCopy[key] = unvisit(entityCopy[key], schema, entities);
-      }
-    });
-
-    return entityCopy;
+    return denormalize(this.schema, entity, unvisit, entities);
   }
 }

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -17,7 +17,21 @@ export const denormalize = (schema, input, unvisit, entities) => {
   Object.keys(schema).forEach((key) => {
     const localSchema = schema[key];
     if (object[key]) {
-      object[key] = unvisit(object[key], localSchema, entities);
+      if (Array.isArray(object[key])) {
+        object[key] = unvisit(object[key], localSchema, entities);
+      } else {
+        const skey = localSchema.key;
+        if (!entities.__cache[skey]) {
+          entities.__cache[skey] = {};
+        }
+
+        if (!entities.__cache[skey][object[key]]) {
+          entities.__cache[skey][object[key]] = {};
+          entities.__cache[skey][object[key]] = unvisit(object[key], localSchema, entities);
+        }
+
+        object[key] = entities.__cache[skey][object[key]];
+      }
     }
   });
   return object;

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -12,28 +12,11 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return object;
 };
 
-const denormalizeItem = (id, schema, unvisit, entities, visitedEntities) => {
-  if (!visitedEntities[schema.key]) {
-    visitedEntities[schema.key] = {};
-  }
-
-  if (!visitedEntities[schema.key][id]) {
-    visitedEntities[schema.key][id] = { ...entities[schema.key][id] };
-    visitedEntities[schema.key][id] = unvisit(id, schema, entities, visitedEntities);
-  }
-
-  return visitedEntities[schema.key][id];
-};
-
 export const denormalize = (schema, input, unvisit, entities, visitedEntities) => {
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     if (object[key]) {
-      if (Array.isArray(object[key])) {
-        object[key] = unvisit(object[key], schema[key], entities, visitedEntities);
-      } else {
-        object[key] = denormalizeItem(object[key], schema[key], unvisit, entities, visitedEntities);
-      }
+      object[key] = unvisit(object[key], schema[key], entities, visitedEntities);
     }
   });
   return object;

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -40,11 +40,11 @@ export default class PolymorphicSchema {
       { id: normalizedValue, schema: this.getSchemaAttribute(value, parent, key) };
   }
 
-  denormalizeValue(value, unvisit, entities) {
+  denormalizeValue(value, unvisit, entities, visitedEntities) {
     if (!this.isSingleSchema && !value.schema) {
       return value;
     }
     const schema = this.isSingleSchema ? this.schema : this.schema[value.schema];
-    return unvisit(value.id || value, schema, entities);
+    return unvisit(value.id || value, schema, entities, visitedEntities);
   }
 }

--- a/src/schemas/Union.js
+++ b/src/schemas/Union.js
@@ -12,7 +12,7 @@ export default class UnionSchema extends PolymorphicSchema {
     return this.normalizeValue(input, parent, key, visit, addEntity);
   }
 
-  denormalize(input, unvisit, entities) {
-    return this.denormalizeValue(input, unvisit, entities);
+  denormalize(input, unvisit, entities, visitedEntities) {
+    return this.denormalizeValue(input, unvisit, entities, visitedEntities);
   }
 }

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -11,12 +11,12 @@ export default class ValuesSchema extends PolymorphicSchema {
     }, {});
   }
 
-  denormalize(input, unvisit, entities) {
+  denormalize(input, unvisit, entities, visitedEntities) {
     return Object.keys(input).reduce((output, key) => {
       const entityOrId = input[key];
       return {
         ...output,
-        [key]: this.denormalizeValue(entityOrId, unvisit, entities)
+        [key]: this.denormalizeValue(entityOrId, unvisit, entities, visitedEntities)
       };
     }, {});
   }


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

`denormalize` method doesn't support [recursive linked entities](https://github.com/paularmstrong/normalizr/issues/216).

# Solution

`__cache` key is added to `entities` object parameter for keeping already visited entities. The same approach is already used in [denormalizr](https://github.com/gpbl/denormalizr/commit/81df0765af65dbf19c85773e1f36978debf4f29e) package.
