### PR TITLE
Add `get idAttribute()` to schema.Entity

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -179,6 +179,7 @@ You *do not* need to define any keys in your entity other than those that hold n
 
 * `define(definition)`: When used, the `definition` passed in will be merged with the original definition passed to the `Entity` constructor. This method tends to be useful for creating circular references in schema.
 * `key`: Returns the key provided to the constructor.
+* `idAttribute`: Returns the idAttribute provided to the constructor in options.
 
 #### Usage
 

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -113,6 +113,7 @@ describe('normalize', () => {
     });
     expect(normalize({ user: { id: '456' } }, recommendation)).toMatchSnapshot();
     expect(idAttributeFn.mock.calls).toMatchSnapshot();
+    expect(recommendation.idAttribute).toBe(idAttributeFn);
   });
 
   it('passes over pre-normalized values', () => {

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -14,6 +14,7 @@ export default class EntitySchema {
 
     this._key = key;
     this._getId = typeof idAttribute === 'function' ? idAttribute : (input) => input[idAttribute];
+    this._idAttribute = idAttribute
     this._mergeStrategy = mergeStrategy;
     this._processStrategy = processStrategy;
     this.define(definition);
@@ -21,6 +22,10 @@ export default class EntitySchema {
 
   get key() {
     return this._key;
+  }
+  
+  get idAttribute() {
+    return this._idAttribute
   }
 
   define(definition) {


### PR DESCRIPTION
# Problem

`schema.Entity` should expose the `idAttribute` it gets in the constructor, like it did in v1.x & v2.x

# Solution

Save `options.idAttribute` in `this._idAttribute`, expose this field with a getter called `idAttribute`.

# TODO

- [ ] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
