### PR TITLE
Support denormalizing from immutable entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "coveralls": "^2.11.15",
     "eslint": "^3.12.2",
     "flow-bin": "^0.37.1",
+    "immutable": "^3.8.1",
     "jest": "^18.0.0",
     "mkdirp": "^0.5.1",
     "npm-run-all": "^3.1.2",

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import UnionSchema from './schemas/Union';
 import ValuesSchema from './schemas/Values';
 import ArraySchema, * as ArrayUtils from './schemas/Array';
 import ObjectSchema, * as ObjectUtils from './schemas/Object';
+import * as ImmutableUtils from './schemas/ImmutableUtils';
 
 const visit = (value, parent, key, schema, addEntity) => {
   if (typeof value !== 'object' || !value) {
@@ -67,7 +68,9 @@ const getEntities = (entities, visitedEntities) => (schema, entityOrId) => {
     visitedEntities[schemaKey] = {};
   }
 
-  const entity = typeof entityOrId === 'object' ? entityOrId : entities[schemaKey][entityOrId];
+  const entity = typeof entityOrId === 'object' ?
+    entityOrId :
+    ImmutableUtils.getIn(entities, [ schemaKey, entityOrId ]);
   const id = schema.getId(entity);
   if (visitedEntities[schemaKey][id]) {
     return id;

--- a/src/index.js
+++ b/src/index.js
@@ -62,25 +62,23 @@ const unvisit = (input, schema, getDenormalizedEntity) => {
   return schema.denormalize(input, unvisit, getDenormalizedEntity);
 };
 
-const getEntity = (entityOrId, schemaKey, entities) => {
+const getEntity = (entityOrId, schemaKey, entities, isImmutable) => {
   if (typeof entityOrId === 'object') {
     return entityOrId;
   }
 
-  if (ImmutableUtils.isImmutable(entities)) {
-    return entities.getIn([ schemaKey, entityOrId.toString() ]);
-  }
-
-  return entities[schemaKey][entityOrId];
+  return isImmutable ?
+    entities.getIn([ schemaKey, entityOrId.toString() ]) :
+    entities[schemaKey][entityOrId];
 };
 
-const getEntities = (entities, visitedEntities) => (schema, entityOrId) => {
+const getEntities = (entities, visitedEntities, isImmutable) => (schema, entityOrId) => {
   const schemaKey = schema.key;
   if (!visitedEntities[schemaKey]) {
     visitedEntities[schemaKey] = {};
   }
 
-  const entity = getEntity(entityOrId, schemaKey, entities);
+  const entity = getEntity(entityOrId, schemaKey, entities, isImmutable);
   const id = schema.getId(entity);
   if (visitedEntities[schemaKey][id]) {
     return id;
@@ -95,6 +93,7 @@ export const denormalize = (input, schema, entities) => {
     return input;
   }
 
-  const getDenormalizedEntity = getEntities(entities, {});
+  const isImmutable = ImmutableUtils.isImmutable(entities);
+  const getDenormalizedEntity = getEntities(entities, {}, isImmutable);
   return unvisit(input, schema, getDenormalizedEntity);
 };

--- a/src/index.js
+++ b/src/index.js
@@ -62,15 +62,25 @@ const unvisit = (input, schema, getDenormalizedEntity) => {
   return schema.denormalize(input, unvisit, getDenormalizedEntity);
 };
 
+const getEntity = (entityOrId, schemaKey, entities) => {
+  if (typeof entityOrId === 'object') {
+    return entityOrId;
+  }
+
+  if (ImmutableUtils.isImmutable(entities)) {
+    return entities.getIn([ schemaKey, entityOrId.toString() ]);
+  }
+
+  return entities[schemaKey][entityOrId];
+};
+
 const getEntities = (entities, visitedEntities) => (schema, entityOrId) => {
   const schemaKey = schema.key;
   if (!visitedEntities[schemaKey]) {
     visitedEntities[schemaKey] = {};
   }
 
-  const entity = typeof entityOrId === 'object' ?
-    entityOrId :
-    ImmutableUtils.getIn(entities, [ schemaKey, entityOrId ]);
+  const entity = getEntity(entityOrId, schemaKey, entities);
   const id = schema.getId(entity);
   if (visitedEntities[schemaKey][id]) {
     return id;

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,10 @@ const unvisit = (input, schema, getDenormalizedEntity) => {
     return method(schema, input, unvisit, getDenormalizedEntity);
   }
 
+  if (input === undefined || input === null) {
+    return input;
+  }
+
   return schema.denormalize(input, unvisit, getDenormalizedEntity);
 };
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -1,5 +1,8 @@
 import * as ImmutableUtils from './ImmutableUtils';
 
+const getDefaultGetId = (idAttribute) => (input) =>
+  ImmutableUtils.isImmutable(input) ? input.get(idAttribute) : input[idAttribute];
+
 export default class EntitySchema {
   constructor(key, definition = {}, options = {}) {
     if (!key || typeof key !== 'string') {
@@ -15,9 +18,7 @@ export default class EntitySchema {
     } = options;
 
     this._key = key;
-    this._getId = typeof idAttribute === 'function' ?
-      idAttribute :
-      (input) => ImmutableUtils.isImmutable(input) ? input.get(idAttribute) : input[idAttribute];
+    this._getId = typeof idAttribute === 'function' ? idAttribute : getDefaultGetId(idAttribute);
     this._idAttribute = idAttribute;
     this._mergeStrategy = mergeStrategy;
     this._processStrategy = processStrategy;

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -1,0 +1,77 @@
+/**
+ * Helpers to enable Immutable compatibility *without* bringing in
+ * the 'immutable' package as a dependency.
+ */
+
+function stringifiedArray(array) {
+  return array.map((item) => item && item.toString());
+}
+
+/**
+ * Check if an object is immutable by checking if it implements the
+ * getIn method.
+ *
+ * @param  {any} object
+ * @return {bool}
+ */
+export function isImmutable(object) {
+  return !!(object && object.getIn);
+}
+
+/**
+ * If the object responds to getIn, that's called directly. Otherwise
+ * recursively apply object/array access to get the value.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @return {any}
+ */
+export function getIn(object, keyPath) {
+  if (object.getIn) {
+    return object.getIn(stringifiedArray(keyPath));
+  }
+
+  return keyPath.reduce((memo, key) => memo[key], object);
+}
+
+/**
+ * If the object responds to hasIn, that's called directly. Otherwise
+ * recursively apply object/array access and check if the full path exists
+ * using hasOwnProperty.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @return {any}
+ */
+export function hasIn(object, keyPath) {
+  if (object.hasIn) {
+    return object.hasIn(stringifiedArray(keyPath));
+  }
+
+  const lastKey = keyPath.pop();
+  const location = getIn(object, keyPath);
+
+  return location.hasOwnProperty(lastKey);
+}
+
+/**
+ * If the object responds to setIn, that's called directly. Otherwise
+ * recursively apply object/array access and set the value at that location.
+ *
+ * @param  {Object, Immutable.Map, Immutable.Record} object
+ * @param  {Array<string, number>} keyPath
+ * @param  {any} value
+ * @return {any}
+ */
+export function setIn(object, keyPath, value) {
+  if (object.setIn) {
+    return object.setIn(stringifiedArray(keyPath), value);
+  }
+
+  const lastKey = keyPath.pop();
+  const location = getIn(object, keyPath);
+
+  location[lastKey] = value;
+
+  return object;
+}

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -30,7 +30,7 @@ export function denormalizeImmutable(schema, input, unvisit, getDenormalizedEnti
   return Object.keys(schema).reduce((object, key) => {
     // Immutable maps cast keys to strings on write so we need to ensure
     // we're accessing them using string keys.
-    const stringKey = typeof key === 'string' ? key : key.toString();
+    const stringKey = `${key}`;
 
     if (object.has(stringKey)) {
       return object.set(stringKey, unvisit(object.get(stringKey), schema[stringKey], getDenormalizedEntity));

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -13,7 +13,7 @@
 export function isImmutable(object) {
   return !!(object && (
     object.hasOwnProperty('__ownerID') || // Immutable.Map
-    (object._map && object._map.object.hasOwnProperty('__ownerID')) // Immutable.Record
+    (object._map && object._map.hasOwnProperty('__ownerID')) // Immutable.Record
   ));
 }
 

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -1,3 +1,5 @@
+import * as ImmutableUtils from './ImmutableUtils';
+
 export const normalize = (schema, input, parent, key, visit, addEntity) => {
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
@@ -13,13 +15,16 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
 };
 
 export const denormalize = (schema, input, unvisit, getDenormalizedEntity) => {
-  const object = { ...input };
+  let processedObject = ImmutableUtils.isImmutable(input) ? input : { ...input };
   Object.keys(schema).forEach((key) => {
-    if (object[key]) {
-      object[key] = unvisit(object[key], schema[key], getDenormalizedEntity);
+    if (ImmutableUtils.hasIn(processedObject, [ key ])) {
+      const localSchema = schema[key];
+      const value = ImmutableUtils.getIn(processedObject, [ key ]);
+      const denormalizedEntity = unvisit(value, localSchema, getDenormalizedEntity);
+      processedObject = ImmutableUtils.setIn(processedObject, [ key ], denormalizedEntity);
     }
   });
-  return object;
+  return processedObject;
 };
 
 export default class ObjectSchema {

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -15,16 +15,17 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
 };
 
 export const denormalize = (schema, input, unvisit, getDenormalizedEntity) => {
-  let processedObject = ImmutableUtils.isImmutable(input) ? input : { ...input };
+  if (ImmutableUtils.isImmutable(input)) {
+    return ImmutableUtils.denormalizeImmutable(schema, input, unvisit, getDenormalizedEntity);
+  }
+
+  const object = { ...input };
   Object.keys(schema).forEach((key) => {
-    if (ImmutableUtils.hasIn(processedObject, [ key ])) {
-      const localSchema = schema[key];
-      const value = ImmutableUtils.getIn(processedObject, [ key ]);
-      const denormalizedEntity = unvisit(value, localSchema, getDenormalizedEntity);
-      processedObject = ImmutableUtils.setIn(processedObject, [ key ], denormalizedEntity);
+    if (object[key]) {
+      object[key] = unvisit(object[key], schema[key], getDenormalizedEntity);
     }
   });
-  return processedObject;
+  return object;
 };
 
 export default class ObjectSchema {

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { fromJS } from 'immutable';
 import { denormalize, normalize, schema } from '../../';
 
 describe(`${schema.Array.name} normalization`, () => {
@@ -84,6 +85,7 @@ describe(`${schema.Array.name} denormalization`, () => {
         }
       };
       expect(denormalize([ 1, 2 ], [ cats ], entities)).toMatchSnapshot();
+      expect(denormalize([ 1, 2 ], [ cats ], fromJS(entities))).toMatchSnapshot();
     });
 
     it('returns the input value if is not an array', () => {
@@ -99,6 +101,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       };
 
       expect(denormalize('123', taco, entities)).toMatchSnapshot();
+      expect(denormalize('123', taco, fromJS(entities))).toMatchSnapshot();
     });
   });
 
@@ -113,6 +116,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       };
       const catList = new schema.Array(cats);
       expect(denormalize([ 1, 2 ], catList, entities)).toMatchSnapshot();
+      expect(denormalize([ 1, 2 ], catList, fromJS(entities))).toMatchSnapshot();
     });
 
     it('denormalizes multiple entities', () => {
@@ -151,6 +155,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       ];
 
       expect(denormalize(input, listSchema, entities)).toMatchSnapshot();
+      expect(denormalize(input, listSchema, fromJS(entities))).toMatchSnapshot();
     });
 
     it('returns the input value if is not an array', () => {
@@ -167,6 +172,7 @@ describe(`${schema.Array.name} denormalization`, () => {
       };
 
       expect(denormalize('123', taco, entities)).toMatchSnapshot();
+      expect(denormalize('123', taco, fromJS(entities))).toMatchSnapshot();
     });
   });
 });

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { fromJS } from 'immutable';
+import { fromJS, Record } from 'immutable';
 import { denormalize, normalize, schema } from '../../';
 
 describe(`${schema.Entity.name} normalization`, () => {
@@ -125,6 +125,32 @@ describe(`${schema.Entity.name} denormalization`, () => {
       },
       foods: {
         1: { id: 1 }
+      }
+    };
+
+    expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(1, menuSchema, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize(2, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(2, menuSchema, fromJS(entities))).toMatchSnapshot();
+  });
+
+  it('denormalizes deep entities with records', () => {
+    const foodSchema = new schema.Entity('foods');
+    const menuSchema = new schema.Entity('menus', {
+      food: foodSchema
+    });
+
+    const Food = new Record({ id: null });
+    const Menu = new Record({ id: null, food: null });
+
+    const entities = {
+      menus: {
+        1: new Menu({ id: 1, food: 1 }),
+        2: new Menu({ id: 2 })
+      },
+      foods: {
+        1: new Food({ id: 1 })
       }
     };
 

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { fromJS } from 'immutable';
 import { denormalize, normalize, schema } from '../../';
 
 describe(`${schema.Entity.name} normalization`, () => {
@@ -108,6 +109,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
       }
     };
     expect(denormalize(1, mySchema, entities)).toMatchSnapshot();
+    expect(denormalize(1, mySchema, fromJS(entities))).toMatchSnapshot();
   });
 
   it('denormalizes deep entities', () => {
@@ -127,7 +129,10 @@ describe(`${schema.Entity.name} denormalization`, () => {
     };
 
     expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(1, menuSchema, fromJS(entities))).toMatchSnapshot();
+
     expect(denormalize(2, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(2, menuSchema, fromJS(entities))).toMatchSnapshot();
   });
 
   it('can denormalize already partially denormalized data', () => {
@@ -146,5 +151,6 @@ describe(`${schema.Entity.name} denormalization`, () => {
     };
 
     expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(1, menuSchema, fromJS(entities))).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { fromJS } from 'immutable';
 import { denormalize, normalize, schema } from '../../';
 
 describe(`${schema.Object.name} normalization`, () => {
@@ -34,6 +35,8 @@ describe(`${schema.Object.name} denormalization`, () => {
       }
     };
     expect(denormalize({ user: 1 }, object, entities)).toMatchSnapshot();
+    expect(denormalize({ user: 1 }, object, fromJS(entities))).toMatchSnapshot();
+    expect(denormalize(fromJS({ user: 1 }), object, fromJS(entities))).toMatchSnapshot();
   });
 
   it('denormalizes plain object shorthand', () => {
@@ -44,5 +47,7 @@ describe(`${schema.Object.name} denormalization`, () => {
       }
     };
     expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, entities)).toMatchSnapshot();
+    expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
+    expect(denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Union.test.js
+++ b/src/schemas/__tests__/Union.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { fromJS } from 'immutable';
 import { denormalize, normalize, schema } from '../../';
 
 describe(`${schema.Union.name} normalization`, () => {
@@ -51,7 +52,10 @@ describe(`${schema.Union.name} denormalization`, () => {
     }, 'type');
 
     expect(denormalize({ id: 1, schema: 'users' }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 1, schema: 'users' }, union, fromJS(entities))).toMatchSnapshot();
+
     expect(denormalize({ id: 2, schema: 'groups' }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 2, schema: 'groups' }, union, fromJS(entities))).toMatchSnapshot();
   });
 
   it('denormalizes an array of multiple entities using a function to infer the schemaAttribute', () => {
@@ -61,7 +65,10 @@ describe(`${schema.Union.name} denormalization`, () => {
     }, (input) => { return input.username ? 'users' : 'groups'; });
 
     expect(denormalize({ id: 1, schema: 'users' }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 1, schema: 'users' }, union, fromJS(entities))).toMatchSnapshot();
+
     expect(denormalize({ id: 2, schema: 'groups' }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 2, schema: 'groups' }, union, fromJS(entities))).toMatchSnapshot();
   });
 
   it('returns the original value no schema is given', () => {
@@ -71,5 +78,6 @@ describe(`${schema.Union.name} denormalization`, () => {
     }, (input) => { return input.username ? 'users' : 'groups'; });
 
     expect(denormalize({ id: 1 }, union, entities)).toMatchSnapshot();
+    expect(denormalize({ id: 1 }, union, fromJS(entities))).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/Values.test.js
+++ b/src/schemas/__tests__/Values.test.js
@@ -1,4 +1,5 @@
 /* eslint-env jest */
+import { fromJS } from 'immutable';
 import { denormalize, normalize, schema } from '../../';
 
 describe(`${schema.Values.name} normalization`, () => {
@@ -65,5 +66,10 @@ describe(`${schema.Values.name} denormalization`, () => {
       fido: { id: 1, schema: 'dogs' },
       fluffy: { id: 1, schema: 'cats' }
     }, valuesSchema, entities)).toMatchSnapshot();
+
+    expect(denormalize({
+      fido: { id: 1, schema: 'dogs' },
+      fluffy: { id: 1, schema: 'cats' }
+    }, valuesSchema, fromJS(entities))).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -11,7 +11,40 @@ Array [
 ]
 `;
 
+exports[`ArraySchema denormalization Class denormalizes a single entity 2`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "Milo",
+  },
+  Object {
+    "id": 2,
+    "name": "Jake",
+  },
+]
+`;
+
 exports[`ArraySchema denormalization Class denormalizes multiple entities 1`] = `
+Array [
+  Object {
+    "id": "123",
+    "type": "cats",
+  },
+  Object {
+    "id": "123",
+    "type": "people",
+  },
+  Object {
+    "id": "789",
+  },
+  Object {
+    "id": "456",
+    "type": "cats",
+  },
+]
+`;
+
+exports[`ArraySchema denormalization Class denormalizes multiple entities 2`] = `
 Array [
   Object {
     "id": "123",
@@ -38,6 +71,13 @@ Object {
 }
 `;
 
+exports[`ArraySchema denormalization Class returns the input value if is not an array 2`] = `
+Object {
+  "fillings": null,
+  "id": "123",
+}
+`;
+
 exports[`ArraySchema denormalization Object denormalizes a single entity 1`] = `
 Array [
   Object {
@@ -51,7 +91,27 @@ Array [
 ]
 `;
 
+exports[`ArraySchema denormalization Object denormalizes a single entity 2`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "Milo",
+  },
+  Object {
+    "id": 2,
+    "name": "Jake",
+  },
+]
+`;
+
 exports[`ArraySchema denormalization Object returns the input value if is not an array 1`] = `
+Object {
+  "fillings": null,
+  "id": "123",
+}
+`;
+
+exports[`ArraySchema denormalization Object returns the input value if is not an array 2`] = `
 Object {
   "fillings": null,
   "id": "123",

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -7,7 +7,23 @@ Object {
 }
 `;
 
+exports[`EntitySchema denormalization can denormalize already partially denormalized data 2`] = `
+Object {
+  "food": Object {
+    "id": 1,
+  },
+  "id": 1,
+}
+`;
+
 exports[`EntitySchema denormalization denormalizes an entity 1`] = `
+Object {
+  "id": 1,
+  "type": "foo",
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes an entity 2`] = `
 Object {
   "id": 1,
   "type": "foo",
@@ -24,6 +40,21 @@ Object {
 `;
 
 exports[`EntitySchema denormalization denormalizes deep entities 2`] = `
+Object {
+  "food": Object {
+    "id": 1,
+  },
+  "id": 1,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities 3`] = `
+Object {
+  "id": 2,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities 4`] = `
 Object {
   "id": 2,
 }

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -60,6 +60,38 @@ Object {
 }
 `;
 
+exports[`EntitySchema denormalization denormalizes deep entities with records 1`] = `
+Object {
+  "food": Object {
+    "id": 1,
+  },
+  "id": 1,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 2`] = `
+Object {
+  "food": Object {
+    "id": 1,
+  },
+  "id": 1,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 3`] = `
+Object {
+  "food": null,
+  "id": 2,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes deep entities with records 4`] = `
+Object {
+  "food": null,
+  "id": 2,
+}
+`;
+
 exports[`EntitySchema normalization idAttribute can build the entity's ID from the parent object 1`] = `
 Object {
   "entities": Object {

--- a/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -7,7 +7,43 @@ Object {
 }
 `;
 
+exports[`ObjectSchema denormalization denormalizes an object 2`] = `
+Object {
+  "user": Object {
+    "id": 1,
+    "name": "Nacho",
+  },
+}
+`;
+
+exports[`ObjectSchema denormalization denormalizes an object 3`] = `
+Object {
+  "user": Object {
+    "id": 1,
+    "name": "Nacho",
+  },
+}
+`;
+
 exports[`ObjectSchema denormalization denormalizes plain object shorthand 1`] = `
+Object {
+  "user": Object {
+    "id": 1,
+    "name": "Jane",
+  },
+}
+`;
+
+exports[`ObjectSchema denormalization denormalizes plain object shorthand 2`] = `
+Object {
+  "user": Object {
+    "id": 1,
+    "name": "Jane",
+  },
+}
+`;
+
+exports[`ObjectSchema denormalization denormalizes plain object shorthand 3`] = `
 Object {
   "user": Object {
     "id": 1,

--- a/src/schemas/__tests__/__snapshots__/Union.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Union.test.js.snap
@@ -8,6 +8,22 @@ Object {
 
 exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 2`] = `
 Object {
+  "id": 1,
+  "type": "users",
+  "username": "Janey",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 3`] = `
+Object {
+  "groupname": "People",
+  "id": 2,
+  "type": "groups",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an array of multiple entities using a function to infer the schemaAttribute 4`] = `
+Object {
   "groupname": "People",
   "id": 2,
   "type": "groups",
@@ -24,6 +40,22 @@ Object {
 
 exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 2`] = `
 Object {
+  "id": 1,
+  "type": "users",
+  "username": "Janey",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 3`] = `
+Object {
+  "groupname": "People",
+  "id": 2,
+  "type": "groups",
+}
+`;
+
+exports[`UnionSchema denormalization denormalizes an object using string schemaAttribute 4`] = `
+Object {
   "groupname": "People",
   "id": 2,
   "type": "groups",
@@ -31,6 +63,12 @@ Object {
 `;
 
 exports[`UnionSchema denormalization returns the original value no schema is given 1`] = `
+Object {
+  "id": 1,
+}
+`;
+
+exports[`UnionSchema denormalization returns the original value no schema is given 2`] = `
 Object {
   "id": 1,
 }

--- a/src/schemas/__tests__/__snapshots__/Values.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Values.test.js.snap
@@ -11,6 +11,19 @@ Object {
 }
 `;
 
+exports[`ValuesSchema denormalization denormalizes the values of an object with the given schema 2`] = `
+Object {
+  "fido": Object {
+    "id": 1,
+    "type": "dogs",
+  },
+  "fluffy": Object {
+    "id": 1,
+    "type": "cats",
+  },
+}
+`;
+
 exports[`ValuesSchema normalization can use a function to determine the schema when normalizing 1`] = `
 Object {
   "entities": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -161,6 +161,10 @@ assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
+assertion-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.0.2.tgz#13ca515d86206da0bac66e834dd397d87581094c"
+
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -1191,6 +1195,13 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
+detect-indent@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-0.2.0.tgz#042914498979ac2d9f3c73e4ff3e6877d3bc92b6"
+  dependencies:
+    get-stdin "^0.1.0"
+    minimist "^0.1.0"
+
 detect-indent@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-4.0.0.tgz#f76d064352cdf43a1cb6ce619c4ee3a9475de208"
@@ -1207,6 +1218,14 @@ doctrine@^1.2.2:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+dts-bundle@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/dts-bundle/-/dts-bundle-0.2.0.tgz#e165e494b00f81a3b6eb64385cbf6d1b486b7a99"
+  dependencies:
+    detect-indent "^0.2.0"
+    glob "^4.0.2"
+    mkdirp "^0.5.0"
 
 duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
@@ -1634,6 +1653,10 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-0.1.0.tgz#5998af24aafc802d15c82c685657eeb8b10d4a91"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"
@@ -1662,6 +1685,15 @@ glob@5.x, glob@^5.0.5:
     minimatch "2 || 3"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^4.0.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^2.0.1"
+    once "^1.3.0"
 
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.1"
@@ -1789,6 +1821,10 @@ iconv-lite@^0.4.13:
 ignore@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
+
+immutable@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2258,16 +2294,9 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
-js-yaml@3.6.1:
+js-yaml@3.6.1, js-yaml@3.x, js-yaml@^3.5.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^2.6.0"
-
-js-yaml@3.x, js-yaml@^3.5.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
@@ -2453,6 +2482,10 @@ lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
+lodash@^3.6.0:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
@@ -2540,7 +2573,7 @@ mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.7:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimatch@2.x:
+minimatch@2.x, minimatch@^2.0.1:
   version "2.0.10"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-2.0.10.tgz#8d087c39c6b38c001b97fca7ce6d0e1e80afbac7"
   dependencies:
@@ -2553,6 +2586,10 @@ minimist@0.0.8, minimist@~0.0.1:
 minimist@1.2.0, minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
+
+minimist@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.1.0.tgz#99df657a52574c21c9057497df742790b2b4c0de"
 
 mkdirp, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.1"
@@ -3462,6 +3499,18 @@ type-check@~0.3.2:
 typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+typescript-definition-tester@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/typescript-definition-tester/-/typescript-definition-tester-0.0.5.tgz#91c574d78ea05b81ed81244d50ec30d8240c356f"
+  dependencies:
+    assertion-error "^1.0.1"
+    dts-bundle "^0.2.0"
+    lodash "^3.6.0"
+
+typescript@^2.1.4:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.5.tgz#6fe9479e00e01855247cea216e7561bafcdbcd4a"
 
 uglify-js@^2.6, uglify-js@^2.6.1:
   version "2.7.5"


### PR DESCRIPTION
Fixes #222 

# Problem

First I want to say that I've been using and following this repo for quite a while and it's great to see `denormalize` finally land! 

It seems that most places I've seen that suggest using `normalizr` also suggest using an immutable store for entities. However, in doing so you lose the ability to use `denormalize`. Adding `immutable` as a dependency would add complexity and bloat for users who are not using immutable data.

# Solution

Update `denormalize` to handle both mutable and immutable entities without actually requiring `immutable` as a dependency.

Support is handled by using simple `getIn`, `setIn`, `hasIn` methods that defer to the immutable implementations if the object is immutable otherwise implement the same behavior on plain javascript objects/arrays. `immutable-js` is required as a dev dependency since it's needed for specs. I just updated the existing specs to also test with immutable entities.

The best part is that it only adds ~70 bytes (compressed) and ~40 bytes (minified + compressed) and doesn't add any external dependencies.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation

# Size Diff

## Before

```
Package:      dist/normalizr.js
Bundle Size:  18.06 KB
Compressed:   3.93 KB

Package:      dist/normalizr.min.js
Bundle Size:  8.76 KB
Compressed:   2.48 KB
```
## After

```
Package:      dist/normalizr.js
Bundle Size:  19.31 KB
Compressed:   4.09 KB

Package:      dist/normalizr.min.js
Bundle Size:  9.25 KB
Compressed:   2.61 KB
```