### PR TITLE
return null instead of empty object

### DIFF
--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -53,14 +53,25 @@ export default class EntitySchema {
 
   denormalize(entityOrId, unvisit, entities) {
     const entity = typeof entityOrId === 'object' ? entityOrId : entities[this.key][entityOrId];
+    if (!entity) {
+      return null;
+    }
+    let failure = false;
     const entityCopy = { ...entity };
     Object.keys(this.schema).forEach((key) => {
       if (entityCopy.hasOwnProperty(key)) {
         const schema = this.schema[key];
-        entityCopy[key] = unvisit(entityCopy[key], schema, entities);
+        const val = unvisit(entityCopy[key], schema, entities);
+        if (val) {
+          entityCopy[key] = val;
+        } else {
+          failure = true;
+        }
       }
     });
-
+    if (failure) {
+      return null;
+    }
     return entityCopy;
   }
 }

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -13,13 +13,25 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
 };
 
 export const denormalize = (schema, input, unvisit, entities) => {
+  if (!input) {
+    return null;
+  }
+  let failure = false;
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     const localSchema = schema[key];
     if (object[key]) {
-      object[key] = unvisit(object[key], localSchema, entities);
+      const val = unvisit(object[key], localSchema, entities);
+      if (val) {
+        object[key] = val;
+      } else {
+        failure = true;
+      }
     }
   });
+  if (failure) {
+    return null;
+  }
   return object;
 };
 

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -45,4 +45,30 @@ describe(`${schema.Object.name} denormalization`, () => {
     };
     expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, entities)).toMatchSnapshot();
   });
+
+  it('returns null when an entity is not found', () => {
+    const userSchema = new schema.Entity('user');
+    const entities = {
+      user: {
+        1: { id: 1, name: 'Jane' }
+      }
+    };
+    expect(denormalize(2, userSchema, entities)).toBeNull();
+  });
+
+  it('returns empty object when a nested entity is not found', () => {
+    const tribeSchema = new schema.Entity('tribe');
+    const userSchema = new schema.Entity('user', {
+      tribe: tribeSchema
+    });
+    const entities = {
+      user: {
+        1: { id: 1, name: 'Jane', tribe: 'tribeId' }
+      },
+      tribe: {
+        tribeId2: { id: 'tribeId2', name: 'cool tribe' }
+      }
+    };
+    expect(denormalize(1, userSchema, entities)).toBeNull();
+  });
 });


### PR DESCRIPTION
# Problem

When an entity is not found during denormalisation, it is supplanted by an empty object. This makes it impossible to guarantee the shape of an object at runtime.

# Solution

When an entity isn't found, even if it's deeply nested, the result of the whole denormalisation should be null.
