### PR TITLE
Handle missing data in denormalize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -83,6 +83,11 @@ const getEntities = (entities, visitedEntities, isImmutable) => (schema, entityO
   }
 
   const entity = getEntity(entityOrId, schemaKey, entities, isImmutable);
+
+  if (typeof entity !== 'object' || entity === null) {
+    return entity;
+  }
+
   const id = schema.getId(entity);
   if (visitedEntities[schemaKey][id]) {
     return id;

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -63,7 +63,7 @@ export default class EntitySchema {
 
   denormalize(entityOrId, unvisit, getDenormalizedEntity) {
     const entity = getDenormalizedEntity(this, entityOrId);
-    if (typeof entity !== 'object') {
+    if (typeof entity !== 'object' || entity === null) {
       return entity;
     }
 

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -135,6 +135,28 @@ describe(`${schema.Entity.name} denormalization`, () => {
     expect(denormalize(2, menuSchema, fromJS(entities))).toMatchSnapshot();
   });
 
+  it('denormalizes to undefined for missing data', () => {
+    const foodSchema = new schema.Entity('foods');
+    const menuSchema = new schema.Entity('menus', {
+      food: foodSchema
+    });
+
+    const entities = {
+      menus: {
+        1: { id: 1, food: 2 }
+      },
+      foods: {
+        1: { id: 1 }
+      }
+    };
+
+    expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(1, menuSchema, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize(2, menuSchema, entities)).toMatchSnapshot();
+    expect(denormalize(2, menuSchema, fromJS(entities))).toMatchSnapshot();
+  });
+
   it('denormalizes deep entities with records', () => {
     const foodSchema = new schema.Entity('foods');
     const menuSchema = new schema.Entity('menus', {

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -92,6 +92,24 @@ Object {
 }
 `;
 
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 1`] = `
+Object {
+  "food": undefined,
+  "id": 1,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 2`] = `
+Object {
+  "food": undefined,
+  "id": 1,
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 3`] = `undefined`;
+
+exports[`EntitySchema denormalization denormalizes to undefined for missing data 4`] = `undefined`;
+
 exports[`EntitySchema normalization idAttribute can build the entity's ID from the parent object 1`] = `
 Object {
   "entities": Object {


### PR DESCRIPTION
Following from discussion here https://github.com/paularmstrong/normalizr/pull/228#discussion_r100351657

# Problem

When an entity is not found during denormalization, it throws an unexpected exception.

```js
const mySchema = new schema.Entity('tacos');
const entities = {
  tacos: {
    1: { id: 1, type: 'foo' }
  }
};

denormalize(3, mySchema, entities)
> TypeError: Cannot read property 'id' of undefined
    at EntitySchema._getId (~/normalizr/dist/normalizr.js:226:65)
    at EntitySchema.getId (~/normalizr/dist/normalizr.js:245:19)
    at ~/normalizr/dist/normalizr.js:635:21
    at EntitySchema.denormalize (~/normalizr/dist/normalizr.js:273:20)
    at unvisit (~/normalizr/dist/normalizr.js:612:17)
    at Object.denormalize$1 [as denormalize] (~/normalizr/dist/normalizr.js:651:10)
    at repl:1:3
    at realRunInThisContextScript (vm.js:22:35)
    at sigintHandlersWrap (vm.js:98:12)
    at ContextifyScript.Script.runInThisContext (vm.js:24:12)
```

# Solution

During denormalization, if an entity is not found return undefined in its place.

*NOTE:* Initially I returned `null` where missing (`null` or `undefined`) data was. I've updated it to handle missing data by returning whatever was there, respecting either `null` or `undefined`.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation