### PR TITLE
Revert recursive denormalization

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -47,8 +47,6 @@ Denormalizes an input based on schema and provided entities from a plain object 
 
 *Special Note:* Be careful with denormalization. Prematurely reverting your data to large, nested objects could cause performance impacts in React (and other) applications.
 
-If your schema and data have recursive references, only the first instance of an entity will be given. Subsequent references will be returned as the `id` provided.
-
 * `input`: **required** The normalized result that should be *de-normalized*. Usually the same value that was given in the `result` key of the output of `normalize`.
 * `schema`: **required** A schema definition that was used to get the value for `input`.
 * `entities`: **required** An object, keyed by entity schema names that may appear in the denormalized output. Also accepts an object with Immutable data.

--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -33,20 +33,6 @@ Object {
 }
 `;
 
-exports[`denormalize denormalizes recursive dependencies 1`] = `
-Object {
-  "id": "123",
-  "title": "Weekly report",
-  "user": Object {
-    "id": "456",
-    "reports": Array [
-      "123",
-    ],
-    "role": "manager",
-  },
-}
-`;
-
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -207,34 +207,4 @@ describe('denormalize', () => {
     });
     expect(() => denormalize('123', article, entities)).not.toThrow();
   });
-
-  it('denormalizes recursive dependencies', () => {
-    const user = new schema.Entity('users');
-    const report = new schema.Entity('reports');
-
-    user.define({
-      reports: [ report ]
-    });
-    report.define({
-      user: user
-    });
-
-    const entities = {
-      reports: {
-        '123': {
-          id: '123',
-          title: 'Weekly report',
-          user: '456'
-        }
-      },
-      users: {
-        '456': {
-          id: '456',
-          role: 'manager',
-          reports: [ '123' ]
-        }
-      }
-    };
-    expect(denormalize('123', report, entities)).toMatchSnapshot();
-  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -76,25 +76,10 @@ const getEntity = (entityOrId, schemaKey, entities, isImmutable) => {
     entities[schemaKey][entityOrId];
 };
 
-const getEntities = (entities, visitedEntities, isImmutable) => (schema, entityOrId) => {
+const getEntities = (entities, isImmutable) => (schema, entityOrId) => {
   const schemaKey = schema.key;
-  if (!visitedEntities[schemaKey]) {
-    visitedEntities[schemaKey] = {};
-  }
 
-  const entity = getEntity(entityOrId, schemaKey, entities, isImmutable);
-
-  if (typeof entity !== 'object' || entity === null) {
-    return entity;
-  }
-
-  const id = schema.getId(entity);
-  if (visitedEntities[schemaKey][id]) {
-    return id;
-  }
-
-  visitedEntities[schemaKey][id] = true;
-  return entity;
+  return getEntity(entityOrId, schemaKey, entities, isImmutable);
 };
 
 export const denormalize = (input, schema, entities) => {
@@ -103,6 +88,6 @@ export const denormalize = (input, schema, entities) => {
   }
 
   const isImmutable = ImmutableUtils.isImmutable(entities);
-  const getDenormalizedEntity = getEntities(entities, {}, isImmutable);
+  const getDenormalizedEntity = getEntities(entities, isImmutable);
   return unvisit(input, schema, getDenormalizedEntity);
 };


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Recursive denormalization doesn't work as expected. If an entity is referenced by two separate entities (not in the same recursive tree), the second reference to the nested entity will not be denormalized properly (See #233)

# Solution

Reverting the recursive handling for now.

# TODO

- [X] Add & update tests
- [X] Ensure CI is passing (lint, tests, flow)
- [X] Update relevant documentation
