### PR TITLE
Use a reference cache to allow recursive references

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -33,6 +33,20 @@ Object {
 }
 `;
 
+exports[`denormalize denormalizes recursive dependencies 1`] = `
+Object {
+  "id": 1,
+  "title": "Weekly report",
+  "user": Object {
+    "id": 1,
+    "reports": Array [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+}
+`;
+
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -207,4 +207,34 @@ describe('denormalize', () => {
     });
     expect(() => denormalize('123', article, entities)).not.toThrow();
   });
+
+  it('denormalizes recursive dependencies', () => {
+    const user = new schema.Entity('users');
+    const report = new schema.Entity('reports');
+
+    user.define({
+      reports: [ report ]
+    });
+    report.define({
+      user: user
+    });
+
+    const entities = {
+      reports: {
+        1: {
+          id: 1,
+          title: 'Weekly report',
+          user: 1
+        }
+      },
+      users: {
+        1: {
+          id: 1,
+          role: 'manager',
+          reports: [ 1 ]
+        }
+      }
+    };
+    expect(denormalize('1', report, entities)).toMatchSnapshot();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -79,19 +79,22 @@ const getEntity = (entityOrId, schemaKey, entities, isImmutable) => {
 const getEntities = (entities, cache, isImmutable) => (schema, entityOrId) => {
   return (handleCacheHit, handleCacheMiss) => {
     const schemaKey = schema.key;
-    const entityId = typeof entityOrId === 'object' ? schema.getId(entityOrId) : entityOrId;
+    const getEntityId = (entity) => typeof entity === 'object' ? schema.getId(entity) : entity;
 
     if (!cache[schemaKey]) {
       cache[schemaKey] = {};
     }
 
-    if (cache[schemaKey][entityId]) {
-      return handleCacheHit(cache[schemaKey][entityId]);
+    if (cache[schemaKey][getEntityId(entityOrId)]) {
+      return handleCacheHit(cache[schemaKey][getEntityId(entityOrId)]);
     }
 
     const entity = getEntity(entityOrId, schemaKey, entities, isImmutable);
 
-    return handleCacheMiss(entity, cache);
+    return handleCacheMiss(entity, (entityToCache) => {
+      cache[schemaKey][getEntityId(entityToCache)] = entityToCache;
+      return cache[schemaKey][getEntityId(entityToCache)];
+    });
   };
 };
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -62,22 +62,29 @@ export default class EntitySchema {
   }
 
   denormalize(entityOrId, unvisit, getDenormalizedEntity) {
-    const entity = getDenormalizedEntity(this, entityOrId);
-    if (typeof entity !== 'object' || entity === null) {
-      return entity;
-    }
+    const getCachedEntity = getDenormalizedEntity(this, entityOrId);
 
-    if (ImmutableUtils.isImmutable(entity)) {
-      return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit, getDenormalizedEntity);
-    }
-
-    const processedEntity = { ...entity };
-    Object.keys(this.schema).forEach((key) => {
-      if (processedEntity.hasOwnProperty(key)) {
-        const schema = this.schema[key];
-        processedEntity[key] = unvisit(processedEntity[key], schema, getDenormalizedEntity);
+    return getCachedEntity((cachedEntity) => {
+      return cachedEntity;
+    }, (entity, cache) => {
+      if (typeof entity !== 'object' || entity === null) {
+        return entity;
       }
+
+      if (ImmutableUtils.isImmutable(entity)) {
+        return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit, getDenormalizedEntity);
+      }
+
+      cache[this.key][this.getId(entity)] = { ...entity };
+
+      const processedEntity = cache[this.key][this.getId(entity)];
+      Object.keys(this.schema).forEach((key) => {
+        if (processedEntity.hasOwnProperty(key)) {
+          const schema = this.schema[key];
+          processedEntity[key] = unvisit(processedEntity[key], schema, getDenormalizedEntity);
+        }
+      });
+      return processedEntity;
     });
-    return processedEntity;
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -75,9 +75,7 @@ export default class EntitySchema {
         return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit, getDenormalizedEntity);
       }
 
-      cache[this.key][this.getId(entity)] = { ...entity };
-
-      const processedEntity = cache[this.key][this.getId(entity)];
+      const processedEntity = cache({ ...entity });
       Object.keys(this.schema).forEach((key) => {
         if (processedEntity.hasOwnProperty(key)) {
           const schema = this.schema[key];


### PR DESCRIPTION
# Problem

Recursive / circular references throw a stack-level too deep error when denormalized.

# Solution

Cache references to the already denormalized entities and use the reference from the cache if it shows back up in a subsequent pass. The bulk of the work is in `src/schemas/Entity.js` – the rest is just passing the cache object around to make sure it's always available to the denormalize method.
