### PR TITLE
Handle recursive relationships in denormalize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ const getUnvisit = (entities) => {
   const cache = {};
   const getEntity = getEntities(entities);
 
-  const unvisit = (input, schema) => {
+  return function unvisit(input, schema) {
     if (typeof schema === 'object' && (!schema.denormalize || typeof schema.denormalize !== 'function')) {
       const method = Array.isArray(schema) ? ArrayUtils.denormalize : ObjectUtils.denormalize;
       return method(schema, input, unvisit);
@@ -98,8 +98,6 @@ const getUnvisit = (entities) => {
 
     return schema.denormalize(input, unvisit);
   };
-
-  return unvisit;
 };
 
 const getEntities = (entities) => {

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -21,10 +21,10 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return values.map((value, index) => visit(value, parent, key, schema, addEntity));
 };
 
-export const denormalize = (schema, input, unvisit, getDenormalizedEntity) => {
+export const denormalize = (schema, input, unvisit) => {
   schema = validateSchema(schema);
-  return Array.isArray(input) ?
-    input.map((entityOrId) => unvisit(entityOrId, schema, getDenormalizedEntity)) :
+  return (input && input.map) ?
+    input.map((entityOrId) => unvisit(entityOrId, schema)) :
     input;
 };
 
@@ -36,9 +36,9 @@ export default class ArraySchema extends PolymorphicSchema {
       .filter((value) => value !== undefined && value !== null);
   }
 
-  denormalize(input, unvisit, getDenormalizedEntity) {
-    return Array.isArray(input) ?
-      input.map((value) => this.denormalizeValue(value, unvisit, getDenormalizedEntity)) :
+  denormalize(input, unvisit) {
+    return (input && input.map) ?
+      input.map((value) => this.denormalizeValue(value, unvisit)) :
       input;
   }
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -61,23 +61,17 @@ export default class EntitySchema {
     return this.getId(input, parent, key);
   }
 
-  denormalize(entityOrId, unvisit, getDenormalizedEntity) {
-    const entity = getDenormalizedEntity(this, entityOrId);
-    if (typeof entity !== 'object' || entity === null) {
-      return entity;
-    }
-
+  denormalize(entity, unvisit) {
     if (ImmutableUtils.isImmutable(entity)) {
-      return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit, getDenormalizedEntity);
+      return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit);
     }
 
-    const processedEntity = { ...entity };
     Object.keys(this.schema).forEach((key) => {
-      if (processedEntity.hasOwnProperty(key)) {
+      if (entity.hasOwnProperty(key)) {
         const schema = this.schema[key];
-        processedEntity[key] = unvisit(processedEntity[key], schema, getDenormalizedEntity);
+        entity[key] = unvisit(entity[key], schema);
       }
     });
-    return processedEntity;
+    return entity;
   }
 }

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -26,14 +26,14 @@ export function isImmutable(object) {
  * @param  {function} getDenormalizedEntity
  * @return {Immutable.Map|Immutable.Record}
  */
-export function denormalizeImmutable(schema, input, unvisit, getDenormalizedEntity) {
+export function denormalizeImmutable(schema, input, unvisit) {
   return Object.keys(schema).reduce((object, key) => {
     // Immutable maps cast keys to strings on write so we need to ensure
     // we're accessing them using string keys.
     const stringKey = `${key}`;
 
     if (object.has(stringKey)) {
-      return object.set(stringKey, unvisit(object.get(stringKey), schema[stringKey], getDenormalizedEntity));
+      return object.set(stringKey, unvisit(object.get(stringKey), schema[stringKey]));
     } else {
       return object;
     }

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -14,15 +14,15 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return object;
 };
 
-export const denormalize = (schema, input, unvisit, getDenormalizedEntity) => {
+export const denormalize = (schema, input, unvisit) => {
   if (ImmutableUtils.isImmutable(input)) {
-    return ImmutableUtils.denormalizeImmutable(schema, input, unvisit, getDenormalizedEntity);
+    return ImmutableUtils.denormalizeImmutable(schema, input, unvisit);
   }
 
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     if (object[key]) {
-      object[key] = unvisit(object[key], schema[key], getDenormalizedEntity);
+      object[key] = unvisit(object[key], schema[key]);
     }
   });
   return object;

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -40,11 +40,11 @@ export default class PolymorphicSchema {
       { id: normalizedValue, schema: this.getSchemaAttribute(value, parent, key) };
   }
 
-  denormalizeValue(value, unvisit, getDenormalizedEntity) {
+  denormalizeValue(value, unvisit) {
     if (!this.isSingleSchema && !value.schema) {
       return value;
     }
     const schema = this.isSingleSchema ? this.schema : this.schema[value.schema];
-    return unvisit(value.id || value, schema, getDenormalizedEntity);
+    return unvisit(value.id || value, schema);
   }
 }

--- a/src/schemas/Union.js
+++ b/src/schemas/Union.js
@@ -12,7 +12,7 @@ export default class UnionSchema extends PolymorphicSchema {
     return this.normalizeValue(input, parent, key, visit, addEntity);
   }
 
-  denormalize(input, unvisit, getDenormalizedEntity) {
-    return this.denormalizeValue(input, unvisit, getDenormalizedEntity);
+  denormalize(input, unvisit) {
+    return this.denormalizeValue(input, unvisit);
   }
 }

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -11,12 +11,12 @@ export default class ValuesSchema extends PolymorphicSchema {
     }, {});
   }
 
-  denormalize(input, unvisit, getDenormalizedEntity) {
+  denormalize(input, unvisit) {
     return Object.keys(input).reduce((output, key) => {
       const entityOrId = input[key];
       return {
         ...output,
-        [key]: this.denormalizeValue(entityOrId, unvisit, getDenormalizedEntity)
+        [key]: this.denormalizeValue(entityOrId, unvisit)
       };
     }, {});
   }

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -201,4 +201,40 @@ describe(`${schema.Entity.name} denormalization`, () => {
     expect(denormalize(1, menuSchema, entities)).toMatchSnapshot();
     expect(denormalize(1, menuSchema, fromJS(entities))).toMatchSnapshot();
   });
+
+  it('denormalizes recursive dependencies', () => {
+    const user = new schema.Entity('users');
+    const report = new schema.Entity('reports');
+
+    user.define({
+      reports: [ report ]
+    });
+    report.define({
+      draftedBy: user,
+      publishedBy: user
+    });
+
+    const entities = {
+      reports: {
+        '123': {
+          id: '123',
+          title: 'Weekly report',
+          draftedBy: '456',
+          publishedBy: '456'
+        }
+      },
+      users: {
+        '456': {
+          id: '456',
+          role: 'manager',
+          reports: [ '123' ]
+        }
+      }
+    };
+    expect(denormalize('123', report, entities)).toMatchSnapshot();
+    expect(denormalize('123', report, fromJS(entities))).toMatchSnapshot();
+
+    expect(denormalize('456', user, entities)).toMatchSnapshot();
+    expect(denormalize('456', user, fromJS(entities))).toMatchSnapshot();
+  });
 });

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -237,4 +237,43 @@ describe(`${schema.Entity.name} denormalization`, () => {
     expect(denormalize('456', user, entities)).toMatchSnapshot();
     expect(denormalize('456', user, fromJS(entities))).toMatchSnapshot();
   });
+
+  it('denormalizes entities with referential equality', () => {
+    const user = new schema.Entity('users');
+    const report = new schema.Entity('reports');
+
+    user.define({
+      reports: [ report ]
+    });
+    report.define({
+      draftedBy: user,
+      publishedBy: user
+    });
+
+    const entities = {
+      reports: {
+        '123': {
+          id: '123',
+          title: 'Weekly report',
+          draftedBy: '456',
+          publishedBy: '456'
+        }
+      },
+      users: {
+        '456': {
+          id: '456',
+          role: 'manager',
+          reports: [ '123' ]
+        }
+      }
+    };
+
+    const denormalizedReport = denormalize('123', report, entities);
+
+    expect(denormalizedReport).toBe(denormalizedReport.draftedBy.reports[0]);
+    expect(denormalizedReport.publishedBy).toBe(denormalizedReport.draftedBy);
+
+    // NOTE: Given how immutable data works, referential equality can't be
+    // maintained with nested denormalization.
+  });
 });

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -92,6 +92,100 @@ Object {
 }
 `;
 
+exports[`EntitySchema denormalization denormalizes recursive dependencies 1`] = `
+Object {
+  "draftedBy": Object {
+    "id": "456",
+    "reports": Array [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "id": "123",
+  "publishedBy": Object {
+    "id": "456",
+    "reports": Array [
+      [Circular],
+    ],
+    "role": "manager",
+  },
+  "title": "Weekly report",
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes recursive dependencies 2`] = `
+Object {
+  "draftedBy": Object {
+    "id": "456",
+    "reports": Array [
+      Object {
+        "draftedBy": "456",
+        "id": "123",
+        "publishedBy": "456",
+        "title": "Weekly report",
+      },
+    ],
+    "role": "manager",
+  },
+  "id": "123",
+  "publishedBy": Object {
+    "id": "456",
+    "reports": Array [
+      Object {
+        "draftedBy": "456",
+        "id": "123",
+        "publishedBy": "456",
+        "title": "Weekly report",
+      },
+    ],
+    "role": "manager",
+  },
+  "title": "Weekly report",
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes recursive dependencies 3`] = `
+Object {
+  "id": "456",
+  "reports": Array [
+    Object {
+      "draftedBy": [Circular],
+      "id": "123",
+      "publishedBy": [Circular],
+      "title": "Weekly report",
+    },
+  ],
+  "role": "manager",
+}
+`;
+
+exports[`EntitySchema denormalization denormalizes recursive dependencies 4`] = `
+Object {
+  "id": "456",
+  "reports": Array [
+    Object {
+      "draftedBy": Object {
+        "id": "456",
+        "reports": Array [
+          "123",
+        ],
+        "role": "manager",
+      },
+      "id": "123",
+      "publishedBy": Object {
+        "id": "456",
+        "reports": Array [
+          "123",
+        ],
+        "role": "manager",
+      },
+      "title": "Weekly report",
+    },
+  ],
+  "role": "manager",
+}
+`;
+
 exports[`EntitySchema denormalization denormalizes to undefined for missing data 1`] = `
 Object {
   "food": undefined,


### PR DESCRIPTION
# Problem

Fixes #216 - denormalization with circular/recursive entities. Would replace #238.

# Solution

Turned `unvisit` into a factory function that returns a cache-aware version of the former unvisit. When `unvisiting` an entity, we first check if it's in the cache

Some other benefits:
- `Entity.denormalize` is simpler: given an entity object, denormalize it. Previously it would handle either an ID or an object, but this logic is moved up a level.
- Previously if you denormalized the same entity multiple times (e.g. array of books with the same author) the entities would not be referentially equal. This was due to how we were preventing mutating the entities in the store. With this PR, those entities will have the same object reference.
- No longer need to pass around `getDenormalizedEntities` through all of the denormalizers (it was only every used in the `Entity` schema.
- Works both for mutable and immutable. There's a limitation to the immutable functionality where when it reaches a circuluar dependency it will yield the original (normalized) entity instead of a circular reference. This is a limitation of immutable-js: https://github.com/facebook/immutable-js/issues/259#issuecomment-67899036

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
