### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v3.2.0
 
-* **Added** Support denormoalizing from Immutable entities (gh-228)
+* **Added** Support denormalizing from Immutable entities (gh-228)
 * **Added** Brought back `get idAttribute()` to `schema.Entity` (gh-226)
 * **Fixed** Gracefully handle missing data in `denormalize` (gh-232)
 * **Fixed** Prevent infinite recursion in `denormalize` (gh-220)


### PR DESCRIPTION
# Problem
Typo in CHANGELOG.md: "Support denorm**o**alizing from Immutable entities"

# Solution
Change to "Support denormalizing from Immutable entities"
