### PR TITLE
Add tests for polymorphic collections of entities

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -143,6 +143,37 @@ Object {
 }
 `;
 
+exports[`normalize normalizes polymorphic collections of entities 1`] = `
+Object {
+  "entities": Object {
+    "admins": Object {
+      "1": Object {
+        "id": 1,
+        "name": "Mr. Admin",
+        "type": "admin",
+      },
+    },
+    "visitors": Object {
+      "2": Object {
+        "id": 2,
+        "name": "Ms Visitor",
+        "type": "visitor",
+      },
+    },
+  },
+  "result": Array [
+    Object {
+      "id": 1,
+      "schema": "admins",
+    },
+    Object {
+      "id": 2,
+      "schema": "visitors",
+    },
+  ],
+}
+`;
+
 exports[`normalize passes over pre-normalized values 1`] = `
 Object {
   "entities": Object {


### PR DESCRIPTION
# Problem

This pull requests supplies two failing test cases when data normalized using array schemas is denormalized incorrectly when using the `schema.Array` constructor, but denormalizes correctly when using simple javascript arrays.

## Case 1
Sample data is an array of entities. It was normalized in an ordinary way (`normalize(data, new schema.Array(schema))`. When denormalizing, this approach works: `denormalize(result, [ schema ], entities)`, while this doesn’t: `denormalize(result, new schema.Array(schema), entities)`

Difference between expected and actual sample data:

![image](https://cloud.githubusercontent.com/assets/6834224/24175647/69d8e376-0ea8-11e7-8ca4-a59d3372425f.png)

## Case 2
Sample data is a record with a field that contains an array schema. If the schema was constructed using simple javascript array:
```
schema.define({
    field: [ anotherSchema ]
});
```
denormalization works, whereas if the schema was created using the `schema.Array` consctructor:
```
schema.define({
    field: new schema.Array(anotherSchema)
});
```
denormalization fails. Difference between expected and actual sample data:

![image](https://cloud.githubusercontent.com/assets/6834224/24175656/76734072-0ea8-11e7-9fcd-a4d9cb19ab1b.png)
