### PR TITLE
Add UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "rimraf": "^2.5.4",
     "rollup": "^0.37.0",
     "rollup-plugin-babel": "^2.7.1",
-    "rollup-plugin-filesize": "^1.0.1",
+    "rollup-plugin-filesize": "^1.2.1",
     "rollup-plugin-uglify": "^1.0.1",
     "typescript": "^2.1.4",
     "typescript-definition-tester": "0.0.5"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,22 +2,21 @@ import babel from 'rollup-plugin-babel';
 import filesize from 'rollup-plugin-filesize';
 import uglify from 'rollup-plugin-uglify';
 
+const destBase = 'dist/normalizr'
 const isProduction = process.env.NODE_ENV === 'production';
-const dest = `dist/normalizr${isProduction ? '.min' : ''}.js`;
+const destExtension = `${isProduction ? '.min' : ''}.js`;
 
 export default {
   entry: 'src/index.js',
-  dest,
-  format: 'cjs',
+  moduleName: 'normalizr',
+  targets: [
+    { dest: `${destBase}${destExtension}`, format: 'cjs' },
+    { dest: `${destBase}.umd${destExtension}`, format: 'umd' }
+  ],
   plugins: [
     babel({ babelrc: false, presets: [ 'es2015-rollup', 'stage-1' ] }),
     isProduction && uglify(),
-    filesize({
-      render: (options, size, gzip) => `
-  Package:      ${dest}
-  Bundle Size:  ${size}
-  Compressed:   ${gzip}
-`
-    })
+    filesize(),
   ].filter((plugin) => !!plugin)
 };
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -1049,6 +1049,10 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
+colors@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -1513,9 +1517,9 @@ fileset@0.2.x:
     glob "5.x"
     minimatch "2.x"
 
-filesize@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.3.0.tgz#53149ea3460e3b2e024962a51648aa572cf98122"
+filesize@^3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.5.6.tgz#5fd98f3eac94ec9516ef8ed5782fad84a01a0a1a"
 
 fill-range@^2.1.0:
   version "2.2.3"
@@ -3167,14 +3171,14 @@ rollup-plugin-babel:
     object-assign "^4.1.0"
     rollup-pluginutils "^1.5.0"
 
-rollup-plugin-filesize:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-1.0.1.tgz#0fe0a10ae2a8b52c7318f16eb8e87d75301920b7"
+rollup-plugin-filesize@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-1.2.1.tgz#2e976a9dc7a7a654ddb8fc5a09358829df87d8ff"
   dependencies:
     boxen "^0.2.0"
-    chalk "^1.1.1"
+    colors "^1.1.2"
     deep-assign "^2.0.0"
-    filesize "^3.2.0"
+    filesize "^3.5.6"
     gzip-size "^3.0.0"
 
 rollup-plugin-uglify:


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
I added a UMD build to the rollup config.

With multiple rollup targets, we can no longer pass a 'dest' into the
filesize plugin. I updated the filesize plugin version because 1.2's
default renderer shows the output path.

Multiple targets might be a good approach to minification also.

I can add that to this PR if you'd like.

# TODO

- [ ] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
