### PR TITLE
fix(definitions): Fixed Entity#key definition for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace schema {
   export class Entity {
     constructor(key: string, definition?: Schema, options?: EntityOptions)
     define(definition: Schema): void
-    key(): string
+    key: string
   }
 
   export class Object {

--- a/src/__tests__/typescript/entity.ts
+++ b/src/__tests__/typescript/entity.ts
@@ -31,3 +31,5 @@ const tweet = new schema.Entity('tweets', { user: user }, {
 
 const normalizedData = normalize(data, tweet);
 const denormalizedData = denormalize(normalizedData.result, tweet, normalizedData.entities);
+
+const isTweet = tweet.key === 'tweets';

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -16,6 +16,11 @@ describe(`${schema.Entity.name} normalization`, () => {
     it('key name must be a string', () => {
       expect(() => new schema.Entity(42)).toThrow();
     });
+
+    it('key getter should return key passed to constructor', () => {
+      const user = new schema.Entity('users');
+      expect(user.key === 'users');
+    });
   });
 
   describe('idAttribute', () => {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Wrong definition for Entity#key

`Entity.key` property is defined using getter (https://github.com/paularmstrong/normalizr/blob/master/src/schemas/Entity.js#L28), but in the definition there is a `key(): string` method (https://github.com/paularmstrong/normalizr/blob/master/index.d.ts#L20) which is wrong.

# Solution

Fixed index.d.ts based on source code: https://github.com/paularmstrong/normalizr/blob/master/src/schemas/Entity.js#L28

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
