### PR TITLE
Use processedEntity to get idAttribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const visit = (value, parent, key, schema, addEntity) => {
 
 const addEntities = (entities) => (schema, processedEntity, value, parent, key) => {
   const schemaKey = schema.key;
-  const id = schema.getId(value, parent, key);
+  const id = schema.getId(processedEntity, parent, key);
   if (!(schemaKey in entities)) {
     entities[schemaKey] = {};
   }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -58,7 +58,7 @@ export default class EntitySchema {
     });
 
     addEntity(this, processedEntity, input, parent, key);
-    return this.getId(input, parent, key);
+    return this.getId(processedEntity, parent, key);
   }
 
   denormalize(entity, unvisit) {

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -93,9 +93,21 @@ describe(`${schema.Entity.name} normalization`, () => {
       // If not run before, this schema would require a parent object with key "message"
       const myEntity = new schema.Entity('entries', {
         data: { attachment: attachmentEntity }
-      }, { idAttribute: (input) => Object.values(input)[0].id, processStrategy });
+      }, { idAttribute: (input) => input.id, processStrategy });
 
       expect(normalize({ message: { id: '123', data: { attachment: { id: '456' } } } }, myEntity)).toMatchSnapshot();
+    });
+
+    it('is run before and passed to the schema normalization', () => {
+      const processStrategy = (input) => ({ ...input, compId: `${input.id}-${input.sid}` });
+      // If not run before, compId wouldn't exist
+      const myEntity = new schema.Entity('patrons', undefined,
+        { idAttribute: 'compId', processStrategy }
+      );
+
+      expect(
+        normalize([ { id: '123', sid: '456' }, { id: '123', sid: '789' } ], [ myEntity ])
+      ).toMatchSnapshot();
     });
   });
 });

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -370,3 +370,26 @@ Object {
   "result": "123",
 }
 `;
+
+exports[`EntitySchema normalization processStrategy is run before and passed to the schema normalization 2`] = `
+Object {
+  "entities": Object {
+    "patrons": Object {
+      "123-456": Object {
+        "compId": "123-456",
+        "id": "123",
+        "sid": "456",
+      },
+      "123-789": Object {
+        "compId": "123-789",
+        "id": "123",
+        "sid": "789",
+      },
+    },
+  },
+  "result": Array [
+    "123-456",
+    "123-789",
+  ],
+}
+`;


### PR DESCRIPTION
# Problem

Changes made to the object in `processStrategy` are not available to the `idAttribute` unless the value is mutated in `processStrategy`.

See discussion in #258 

# Solution

Change source to use `processedEntity` to get the ID, rather than the non-normalized value. This allows us to get the ID using a string rather than a function without mutating the input value.

## Alternative Solution

Don't mutate the input value and pass a function to `idAttirbute` that returns the computed ID **value**.

# TODO

- [x] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow) **Requires discussion**
- [x] Update relevant documentation **none?**

# Issues
There is [one test](https://github.com/paularmstrong/normalizr/blob/master/src/__tests__/index.test.js#L108) that's failing due to this change. Since **this is a breaking change**, I thought we could discuss the possible solutions here; before I changed the intent of the library/tests.

```js
  it('uses the non-normalized input when getting the ID for an entity', () => {
    const userEntity = new schema.Entity('users');
    const idAttributeFn = jest.fn((nonNormalized, parent, key) => nonNormalized.user.id);
    const recommendation = new schema.Entity('recommendations', { user: userEntity }, {
      idAttribute: idAttributeFn
    });
    expect(normalize({ user: { id: '456' } }, recommendation)).toMatchSnapshot();
    expect(idAttributeFn.mock.calls).toMatchSnapshot();
    expect(recommendation.idAttribute).toBe(idAttributeFn);
  });
```

This change goes pretty much against the intent of this test since it's clearly now passing the partially normalized output to the `getId` function:

```js
  // Entity.js:51
  normalize(input, parent, key, visit, addEntity) {
    const processedEntity = this._processStrategy(input, parent, key);
    Object.keys(this.schema).forEach((key) => {
      if (processedEntity.hasOwnProperty(key) && typeof processedEntity[key] === 'object') {
        const schema = this.schema[key];
        // HERE, we're normalizing child schemas before passing to getId
        processedEntity[key] = visit(processedEntity[key], processedEntity, key, schema, addEntity);
      }
    });

    addEntity(this, processedEntity, input, parent, key);
    // Here's the only change I made, passing processedEntity, vs input
    return this.getId(processedEntity, parent, key);
  }
```

I see a couple options to move forward. Please let me know which one you'd prefer @paularmstrong
- If you want to move forward with this, we can discuss options en route to a breaking change (also [see additional discussion here](https://github.com/paularmstrong/normalizr/issues/258#issuecomment-300592753))
- Close this, in favor of simply updating the doc --> #260 
