### PR TITLE
added afterStrategy option to schema.Entity

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import uglify from 'rollup-plugin-uglify';
 
 const isProduction = process.env.NODE_ENV === 'production';
 
-const destBase = 'dist/normalizr'
+const destBase = 'dist/normalizr';
 const destExtension = `${isProduction ? '.min' : ''}.js`;
 
 export default {
@@ -18,7 +18,7 @@ export default {
   plugins: [
     babel({ babelrc: false, presets: [ 'es2015-rollup', 'stage-1' ] }),
     isProduction && uglify(),
-    filesize(),
+    filesize()
   ].filter((plugin) => !!plugin)
 };
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -14,7 +14,8 @@ export default class EntitySchema {
       mergeStrategy = (entityA, entityB) => {
         return { ...entityA, ...entityB };
       },
-      processStrategy = (input) => ({ ...input })
+      processStrategy = (input) => ({ ...input }),
+      afterStrategy = (input) => ({ ...input })
     } = options;
 
     this._key = key;
@@ -22,6 +23,7 @@ export default class EntitySchema {
     this._idAttribute = idAttribute;
     this._mergeStrategy = mergeStrategy;
     this._processStrategy = processStrategy;
+    this._afterStrategy = afterStrategy;
     this.define(definition);
   }
 
@@ -56,8 +58,7 @@ export default class EntitySchema {
         processedEntity[key] = visit(processedEntity[key], processedEntity, key, schema, addEntity);
       }
     });
-
-    addEntity(this, processedEntity, input, parent, key);
+    addEntity(this, this._afterStrategy(processedEntity), input, parent, key);
     return this.getId(input, parent, key);
   }
 

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -112,9 +112,9 @@ describe(`${schema.Entity.name} normalization`, () => {
         user: {
           id: 2,
           name: 'child',
-          created: '01-01-2017'
+          created: '2017-05-07T22:31:28.307185'
         },
-        created: '02-01-2017'
+        created: '2017-05-07T22:31:28.307185'
       };
       const Room = new Record({ id: null, title: null, user: null, created: null }, 'room');
       const User = new Record({ id: null, name: null, created: null }, 'user');

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -211,7 +211,7 @@ Object {
   "entities": Object {
     "rooms": Object {
       "1": Object {
-        "created": "2017-02-01T05:00:00.000Z",
+        "created": "2017-05-07T22:31:28.307Z",
         "id": 1,
         "title": "parent",
         "user": 2,
@@ -219,7 +219,7 @@ Object {
     },
     "users": Object {
       "2": Object {
-        "created": "2017-01-01T05:00:00.000Z",
+        "created": "2017-05-07T22:31:28.307Z",
         "id": 2,
         "name": "child",
       },

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -206,6 +206,29 @@ exports[`EntitySchema denormalization denormalizes to undefined for missing data
 
 exports[`EntitySchema denormalization denormalizes to undefined for missing data 4`] = `undefined`;
 
+exports[`EntitySchema normalization afterStrategy is applied to every entity after being normalized 1`] = `
+Object {
+  "entities": Object {
+    "rooms": Object {
+      "1": Object {
+        "created": "2017-02-01T05:00:00.000Z",
+        "id": 1,
+        "title": "parent",
+        "user": 2,
+      },
+    },
+    "users": Object {
+      "2": Object {
+        "created": "2017-01-01T05:00:00.000Z",
+        "id": 2,
+        "name": "child",
+      },
+    },
+  },
+  "result": 1,
+}
+`;
+
 exports[`EntitySchema normalization idAttribute can build the entity's ID from the parent object 1`] = `
 Object {
   "entities": Object {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

**normalizr** options allows you to specify how data will be transformed before being normalized just by passing a **processStrategy** function which is awesome; 

Unfortunately there is no option to post-process  each normalized entity.
One use-case is to cast each entity to an immutable.Record before being handled by a reducer 
https://github.com/paularmstrong/normalizr/issues/206, https://github.com/paularmstrong/normalizr/issues/199,

# Solution

add an **afterStrategy** option (such as **processStrategy**) wich receives each normalized entity and returns the entity transformed.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
