### PR TITLE
hasOwnProperty error

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -122,6 +122,23 @@ describe('normalize', () => {
 
     expect(normalize({ id: '123', title: 'normalizr is great!', author: 1 }, articleEntity)).toMatchSnapshot();
   });
+
+  it('can normalize object without proper object prototype inheritance', () => {
+    const test = { id: 1, elements: [] };
+    test.elements.push(Object.assign(
+      Object.create(null),
+      {
+        id: 18,
+        name: 'test'
+      }
+    ));
+
+    const testEntity = new schema.Entity('test', {
+      elements: [ new schema.Entity('elements') ]
+    });
+
+    expect(() => normalize(test, testEntity)).not.toThrow();
+  });
 });
 
 describe('denormalize', () => {

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -12,8 +12,8 @@
  */
 export function isImmutable(object) {
   return !!(object && (
-    object.hasOwnProperty('__ownerID') || // Immutable.Map
-    (object._map && object._map.hasOwnProperty('__ownerID')) // Immutable.Record
+    (object.hasOwnProperty && object.hasOwnProperty('__ownerID')) || // Immutable.Map
+    (object._map && object._map.hasOwnProperty && object._map.hasOwnProperty('__ownerID')) // Immutable.Record
   ));
 }
 

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -13,7 +13,8 @@
 export function isImmutable(object) {
   return !!(object && (
     (typeof object.hasOwnProperty === 'function' && object.hasOwnProperty('__ownerID')) || // Immutable.Map
-    (object._map && typeof object._map.hasOwnProperty === 'function' && object._map.hasOwnProperty('__ownerID')) // Immutable.Record
+    (object._map && typeof object._map.hasOwnProperty === 'function' &&
+      object._map.hasOwnProperty('__ownerID')) // Immutable.Record
   ));
 }
 

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -12,8 +12,8 @@
  */
 export function isImmutable(object) {
   return !!(object && (
-    (object.hasOwnProperty && object.hasOwnProperty('__ownerID')) || // Immutable.Map
-    (object._map && object._map.hasOwnProperty && object._map.hasOwnProperty('__ownerID')) // Immutable.Record
+    (typeof object.hasOwnProperty === 'function' && object.hasOwnProperty('__ownerID')) || // Immutable.Map
+    (object._map && typeof object._map.hasOwnProperty === 'function' && object._map.hasOwnProperty('__ownerID')) // Immutable.Record
   ));
 }
 


### PR DESCRIPTION
# Problem

I had exceptions when normalizing objects who don't inherit from Object.prototype.
This PR is related to #246 

# Solution

Check if object has `hasOwnProperty` before calling it.