### PR TITLE
Change `result` to `entities`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,7 @@ Denormalizes an input based on schema and provided entities from a plain object 
 
 If your schema and data have recursive references, only the first instance of an entity will be given. Subsequent references will be returned as the `id` provided.
 
-* `input`: **required** The normalized result that should be *de-normalized*. Usually the same value that was given in the `result` key of the output of `normalize`.
+* `input`: **required** The normalized result that should be *de-normalized*. Usually the same value that was given in the `entities` key of the output of `normalize`.
 * `schema`: **required** A schema definition that was used to get the value for `input`.
 * `entities`: **required** An object, keyed by entity schema names that may appear in the denormalized output. Also accepts an object with Immutable data.
 


### PR DESCRIPTION
# Problem

I'm new to normalizr and playing around trying to `normalize` some data, then `denormalize` it.

Based on what I'm seeing `input` should be `normalize(data).entities` rather than `normalize(data).result`.

# Solution

Modify documentation.