### PR TITLE
denormalize: replace falsy input check with undefined input check

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -146,8 +146,8 @@ describe('denormalize', () => {
     expect(() => denormalize({})).toThrow();
   });
 
-  it('returns the input if falsy', () => {
-    expect(denormalize(false, {}, {})).toBe(false);
+  it('returns the input if undefined', () => {
+    expect(denormalize(undefined, {}, {})).toBeUndefined();
   });
 
   it('denormalizes entities', () => {

--- a/src/index.js
+++ b/src/index.js
@@ -117,9 +117,7 @@ const getEntities = (entities) => {
 };
 
 export const denormalize = (input, schema, entities) => {
-  if (!input) {
-    return input;
+  if (typeof input !== 'undefined') {
+    return getUnvisit(entities)(input, schema);
   }
-
-  return getUnvisit(entities)(input, schema);
 };


### PR DESCRIPTION
Returning falsy input causes valid ids such as "" and 0 to be returned,
even if they could otherwise be properly denormalized. Loosening this
check to undefined will allow `null` to be processed, for example, but
that shouldn't be too much of an issue.

<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

`denormalize` returns unprocessed `input` value when `input` is falsy. `0` and `""` are both falsy but are potentially valid inputs. See https://github.com/paularmstrong/normalizr/issues/278

# Solution

Instead of checking for falsy values, check for undefined. When a normalization has no result, the value given as input will likely be undefined. Some cases that should be and were previously short circuited will  not be (e.g. `false`, `null`), but the value:cost ratio of handling those cases explicitly seems low.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation

(note: not sure documentation needs to be updated here, as this is fixing a bug)
