### PR TITLE
Introduce `Map` schema

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@
   - [Object](#objectdefinition)
   - [Union](#uniondefinition-schemaattribute)
   - [Values](#valuesdefinition-schemaattribute)
+  - [Map](#mapdefinition-schemaattribute)
 
 ## `normalize(data, schema)`
 
@@ -404,5 +405,42 @@ const normalizedData = normalize(data, valuesSchema);
     '1': { id: 1, schema: 'admins' },
     '2': { id: 2, schema: 'users' }
   }
+}
+```
+
+### `Map(definition, schemaAttribute)`
+
+Describes an array of objects whose values follow the given schema. Used for extracting an array-of-objects into a map-of-ids.
+
+* `definition`: **required** A singular schema that this array contains *or* a mapping of schema to attribute values.
+* `schemaAttribute`: *optional* (required if `definition` is not a singular schema) The attribute on each entity found that defines what schema, per the definition mapping, to use when normalizing.  
+Can be a string or a function. If given a function, accepts the following arguments:  
+  * `value`: The input value of the entity.
+  * `parent`: The parent object of the input array.
+  * `key`: The key at which the input array appears on the parent object.
+
+#### Instance Methods
+
+* `define(definition)`: When used, the `definition` passed in will be merged with the original definition passed to the `Map` constructor. This method tends to be useful for creating circular references in schema.
+
+#### Usage
+
+```js
+const data = [ { id: 1, name: 'oliver' }, { id: 2, name: 'waldo' } ];
+
+const pet = new schema.Entity('pets');
+const mapSchema = new schema.Map(pet);
+
+const normalizedData = normalize(data, mapSchema);
+```
+
+#### Output
+
+```js
+{
+  entities: {
+    pets: { '1': { id: 1, name: 'oliver' }, '2': { id: 2, name: 'waldo' } }
+  },
+  result: { '1': 1, '2': 2 }
 }
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,6 +34,8 @@ declare namespace schema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }
+
+  export class Map extends Values {}
 }
 
 export type Schema =
@@ -42,11 +44,13 @@ export type Schema =
   schema.Object |
   schema.Union |
   schema.Values |
+  schema.Map |
   schema.Array[] |
   schema.Entity[] |
   schema.Object[] |
   schema.Union[] |
   schema.Values[] |
+  schema.Map[] |
   {[key: string]: Schema};
 
 export function normalize(

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import EntitySchema from './schemas/Entity';
 import UnionSchema from './schemas/Union';
 import ValuesSchema from './schemas/Values';
+import MapSchema from './schemas/Map';
 import ArraySchema, * as ArrayUtils from './schemas/Array';
 import ObjectSchema, * as ObjectUtils from './schemas/Object';
 import * as ImmutableUtils from './schemas/ImmutableUtils';
@@ -38,7 +39,8 @@ export const schema = {
   Entity: EntitySchema,
   Object: ObjectSchema,
   Union: UnionSchema,
-  Values: ValuesSchema
+  Values: ValuesSchema,
+  Map: MapSchema
 };
 
 export const normalize = (input, schema) => {

--- a/src/schemas/Map.js
+++ b/src/schemas/Map.js
@@ -1,0 +1,23 @@
+import ValuesSchema from './Values';
+
+export default class MapSchema extends ValuesSchema {
+  normalize(input, parent, key, visit, addEntity) {
+    return Object.keys(input).reduce((output, key) => {
+      const value = input[key];
+      const id = value[this.schema.idAttribute];
+
+      return value !== undefined && value !== null ? {
+        ...output,
+        [id]: this.normalizeValue(value, input, key, visit, addEntity)
+      } : output;
+    }, {});
+  }
+
+  denormalize(input, unvisit) {
+    return Object.keys(input).reduce((output, key) => {
+      const entityOrId = input[key];
+      output.push(this.denormalizeValue(entityOrId, unvisit));
+      return output;
+    }, []);
+  }
+}

--- a/src/schemas/__tests__/Map.test.js
+++ b/src/schemas/__tests__/Map.test.js
@@ -1,0 +1,34 @@
+/* eslint-env jest */
+// import { fromJS } from 'immutable';
+import { denormalize, normalize, schema } from '../../';
+
+describe(`${schema.Map.name} normalization`, () => {
+  it('normalizes the values of an object with the given schema', () => {
+    const dog = new schema.Entity('dogs');
+    const pets = new schema.Map(dog);
+
+    const pet = [
+      { id: 1, name: 'fido' },
+      { id: 2, type: 'oliver' }
+    ];
+
+    expect(normalize(pet, pets)).toMatchSnapshot();
+  });
+});
+
+describe(`${schema.Map.name} denormalization`, () => {
+  it('denormalizes the values of an object with the given schema', () => {
+    const dog = new schema.Entity('dogs');
+    const pets = new schema.Map(dog);
+
+    const entities = { dogs: {
+      1: { id: 1, name: 'fido' },
+      2: { id: 2, type: 'oliver' }
+    } };
+
+    expect(denormalize({
+      '1': 1,
+      '2': 2
+    }, pets, entities)).toMatchSnapshot();
+  });
+});

--- a/src/schemas/__tests__/__snapshots__/Map.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Map.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MapSchema denormalization denormalizes the values of an object with the given schema 1`] = `
+Array [
+  Object {
+    "id": 1,
+    "name": "fido",
+  },
+  Object {
+    "id": 2,
+    "type": "oliver",
+  },
+]
+`;
+
+exports[`MapSchema normalization normalizes the values of an object with the given schema 1`] = `
+Object {
+  "entities": Object {
+    "dogs": Object {
+      "1": Object {
+        "id": 1,
+        "name": "fido",
+      },
+      "2": Object {
+        "id": 2,
+        "type": "oliver",
+      },
+    },
+  },
+  "result": Object {
+    "1": 1,
+    "2": 2,
+  },
+}
+`;


### PR DESCRIPTION
# Problem

GraphQL does [not support maps](https://github.com/facebook/graphql/issues/101). Instead, users are requied to use an array of objects to represent nested data.

Redux (and Mobx) users, on the other hand, are [encouraged](http://redux.js.org/docs/recipes/reducers/NormalizingStateShape.html) to store their data in maps. 

Currently normalizr does not provide an easy way to convert between the two paradigms. 

# Solution

I've added a new Schema based on the Values schema that transforms an array-of-objects into a map.

*Example*

```js
const data = [ { id: 1, name: 'oliver' }, { id: 2, name: 'waldo' } ];

const pet = new schema.Entity('pets');
const mapSchema = new schema.Map(pet);

const normalizedData = normalize(data, mapSchema);
```

*Output*

```js
{
  entities: {
    pets: { '1': { id: 1, name: 'oliver' }, '2': { id: 2, name: 'waldo' } }
  },
  result: { '1': 1, '2': 2 }
}
```

# TODO

- [x] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation