### PR TITLE
Use input as id for unvisitEntity in denormalize

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -35,6 +35,23 @@ Object {
 }
 `;
 
+exports[`denormalize denormalizes with function as idAttribute 1`] = `
+Array [
+  Object {
+    "guest": null,
+    "id": "1",
+    "name": "Esther",
+  },
+  Object {
+    "guest": Object {
+      "guest_id": 1,
+    },
+    "id": "2",
+    "name": "Tom",
+  },
+]
+`;
+
 exports[`normalize can use fully custom entity classes 1`] = `
 Object {
   "entities": Object {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -224,4 +224,27 @@ describe('denormalize', () => {
     });
     expect(() => denormalize('123', article, entities)).not.toThrow();
   });
+
+  it('denormalizes with function as idAttribute', () => {
+    const normalizedData = {
+      'entities': {
+        'patrons': {
+          '1': { 'id': '1', 'guest': null, 'name': 'Esther' },
+          '2': { 'id': '2', 'guest': 'guest-2-1', 'name': 'Tom' }
+        },
+        'guests': { 'guest-2-1': { 'guest_id': 1 } }
+      },
+      'result': [ '1', '2' ]
+    };
+
+    const guestSchema = new schema.Entity('guests', {}, {
+      idAttribute: (value, parent, key) => `${key}-${parent.id}-${value.guest_id}`
+    });
+
+    const patronsSchema = new schema.Entity('patrons', {
+      guest: guestSchema
+    });
+
+    expect(denormalize(normalizedData.result, [ patronsSchema ], normalizedData.entities)).toMatchSnapshot();
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -53,13 +53,11 @@ export const normalize = (input, schema) => {
   return { entities, result };
 };
 
-const unvisitEntity = (input, schema, unvisit, getEntity, cache) => {
-  const entity = getEntity(input, schema);
+const unvisitEntity = (id, schema, unvisit, getEntity, cache) => {
+  const entity = getEntity(id, schema);
   if (typeof entity !== 'object' || entity === null) {
     return entity;
   }
-
-  const id = schema.getId(entity);
 
   if (!cache[schema.key]) {
     cache[schema.key] = {};


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Denormalizing fails if `idAttribute` option of `EntitySchema` used as a function which uses `parent` or `key` parameters.

Consider this use case

```
const data = [
    { id: '1', guest: null, name: 'Esther' },
    { id: '2', guest: {guest_id: 1}, name: 'Tom' }
]

const guestSchema = new schema.Entity('guests', {}, {
    idAttribute: (value, parent, key) => `${key}-${parent.id}-${value.guest_id}`
})

const patronsSchema = new schema.Entity('patrons', {
    guest: guestSchema
})
const normalizedData = normalize(data, [patronsSchema])
const denormalizedData = denormalize(
    normalizedData.result, 
    [patronsSchema], 
    normalizedData.entities
)
```
Expected `denormalizedData` to be equal to `data` but got error

`TypeError: Cannot read property 'id' of undefined`

# Solution

`unvisitEntity` calls `schema.getId(entity);` which is useless because 1)not all nesessary parameters passed and 2) we already have `input` as id

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
