### PR TITLE
Avoid circular structures when denormalizing

### DIFF
--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -21,10 +21,12 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return values.map((value, index) => visit(value, parent, key, schema, addEntity));
 };
 
-export const denormalize = (schema, input, unvisit) => {
+export const denormalize = (schema, input, unvisit, cache) => {
   schema = validateSchema(schema);
   return (input && input.map) ?
-    input.map((entityOrId) => unvisit(entityOrId, schema)) :
+    input.map((entityOrId) => {
+      return unvisit(entityOrId, schema, cache);
+    }) :
     input;
 };
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -61,15 +61,15 @@ export default class EntitySchema {
     return this.getId(input, parent, key);
   }
 
-  denormalize(entity, unvisit) {
+  denormalize(entity, unvisit, cache) {
     if (ImmutableUtils.isImmutable(entity)) {
-      return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit);
+      return ImmutableUtils.denormalizeImmutable(this.schema, entity, unvisit, cache);
     }
 
     Object.keys(this.schema).forEach((key) => {
       if (entity.hasOwnProperty(key)) {
         const schema = this.schema[key];
-        entity[key] = unvisit(entity[key], schema);
+        entity[key] = unvisit(entity[key], schema, cache);
       }
     });
     return entity;

--- a/src/schemas/ImmutableUtils.js
+++ b/src/schemas/ImmutableUtils.js
@@ -26,16 +26,15 @@ export function isImmutable(object) {
  * @param  {function} getDenormalizedEntity
  * @return {Immutable.Map|Immutable.Record}
  */
-export function denormalizeImmutable(schema, input, unvisit) {
+export function denormalizeImmutable(schema, input, unvisit, cache) {
   return Object.keys(schema).reduce((object, key) => {
     // Immutable maps cast keys to strings on write so we need to ensure
     // we're accessing them using string keys.
     const stringKey = `${key}`;
 
     if (object.has(stringKey)) {
-      return object.set(stringKey, unvisit(object.get(stringKey), schema[stringKey]));
-    } else {
-      return object;
+      return object.set(stringKey, unvisit(object.get(stringKey), schema[stringKey], cache));
     }
+    return object;
   }, input);
 }

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -14,15 +14,15 @@ export const normalize = (schema, input, parent, key, visit, addEntity) => {
   return object;
 };
 
-export const denormalize = (schema, input, unvisit) => {
+export const denormalize = (schema, input, unvisit, cache) => {
   if (ImmutableUtils.isImmutable(input)) {
-    return ImmutableUtils.denormalizeImmutable(schema, input, unvisit);
+    return ImmutableUtils.denormalizeImmutable(schema, input, unvisit, cache);
   }
 
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     if (object[key]) {
-      object[key] = unvisit(object[key], schema[key]);
+      object[key] = unvisit(object[key], schema[key], cache);
     }
   });
   return object;

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -99,7 +99,7 @@ Object {
   "draftedBy": Object {
     "id": "456",
     "reports": Array [
-      [Circular],
+      "123",
     ],
     "role": "manager",
   },
@@ -107,7 +107,7 @@ Object {
   "publishedBy": Object {
     "id": "456",
     "reports": Array [
-      [Circular],
+      "123",
     ],
     "role": "manager",
   },
@@ -120,12 +120,7 @@ Object {
   "draftedBy": Object {
     "id": "456",
     "reports": Array [
-      Object {
-        "draftedBy": "456",
-        "id": "123",
-        "publishedBy": "456",
-        "title": "Weekly report",
-      },
+      "123",
     ],
     "role": "manager",
   },
@@ -133,12 +128,7 @@ Object {
   "publishedBy": Object {
     "id": "456",
     "reports": Array [
-      Object {
-        "draftedBy": "456",
-        "id": "123",
-        "publishedBy": "456",
-        "title": "Weekly report",
-      },
+      "123",
     ],
     "role": "manager",
   },
@@ -151,9 +141,9 @@ Object {
   "id": "456",
   "reports": Array [
     Object {
-      "draftedBy": [Circular],
+      "draftedBy": "456",
       "id": "123",
-      "publishedBy": [Circular],
+      "publishedBy": "456",
       "title": "Weekly report",
     },
   ],
@@ -166,21 +156,9 @@ Object {
   "id": "456",
   "reports": Array [
     Object {
-      "draftedBy": Object {
-        "id": "456",
-        "reports": Array [
-          "123",
-        ],
-        "role": "manager",
-      },
+      "draftedBy": "456",
       "id": "123",
-      "publishedBy": Object {
-        "id": "456",
-        "reports": Array [
-          "123",
-        ],
-        "role": "manager",
-      },
+      "publishedBy": "456",
       "title": "Weekly report",
     },
   ],


### PR DESCRIPTION
### Problem

The problem is outlined in detail in [this issue](https://github.com/paularmstrong/normalizr/issues/296) and can be clearly seen in the snapshot tests:
https://github.com/paularmstrong/normalizr/blob/c9c8c8bfd616c76446c3d687c6c6d3cd1c48550c/src/schemas/__tests__/__snapshots__/Entity.test.js.snap#L98-L116

### Solution

#### Changing the denormalization algorithm to always pass down the list of ancestors.
When denormalizing an `Entity` we pass all already expanded references of the subtree as the `cache` parameter.

This has two benefits:
- find out whether or not to denormalize a given entity by looking into the `cache`
- avoids #233 by default

### TODO

- [x] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
