### PR TITLE
Fix type error for array+object shorthand

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ export type Schema =
   schema.Object[] |
   schema.Union[] |
   schema.Values[] |
-  {[key: string]: Schema};
+  {[key: string]: Schema | Schema[]};
 
 export function normalize(
   data: any,


### PR DESCRIPTION
Fixes #322

<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem
Something like this didn't work before:

```js
const allFeedSchema = new schema.Entity('posts', { authors: [{ node: authorSchema }] });
```

# Solution

Allow array of schemas.

# TODO

- [ ] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
