### PR TITLE
Add support for circular references in JS objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,17 @@ import ArraySchema, * as ArrayUtils from './schemas/Array';
 import ObjectSchema, * as ObjectUtils from './schemas/Object';
 import * as ImmutableUtils from './schemas/ImmutableUtils';
 
-const visit = (value, parent, key, schema, addEntity) => {
+const visit = (value, parent, key, schema, addEntity, visitedEntities) => {
   if (typeof value !== 'object' || !value) {
     return value;
   }
 
   if (typeof schema === 'object' && (!schema.normalize || typeof schema.normalize !== 'function')) {
     const method = Array.isArray(schema) ? ArrayUtils.normalize : ObjectUtils.normalize;
-    return method(schema, value, parent, key, visit, addEntity);
+    return method(schema, value, parent, key, visit, addEntity, visitedEntities);
   }
 
-  return schema.normalize(value, parent, key, visit, addEntity);
+  return schema.normalize(value, parent, key, visit, addEntity, visitedEntities);
 };
 
 const addEntities = (entities) => (schema, processedEntity, value, parent, key) => {
@@ -48,8 +48,8 @@ export const normalize = (input, schema) => {
 
   const entities = {};
   const addEntity = addEntities(entities);
-
-  const result = visit(input, input, null, schema, addEntity);
+  const visitedEntities = new Set();
+  const result = visit(input, input, null, schema, addEntity, visitedEntities);
   return { entities, result };
 };
 

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -11,14 +11,14 @@ const validateSchema = (definition) => {
 
 const getValues = (input) => (Array.isArray(input) ? input : Object.keys(input).map((key) => input[key]));
 
-export const normalize = (schema, input, parent, key, visit, addEntity) => {
+export const normalize = (schema, input, parent, key, visit, addEntity, visitedEntities) => {
   schema = validateSchema(schema);
 
   const values = getValues(input);
 
   // Special case: Arrays pass *their* parent on to their children, since there
   // is not any special information that can be gathered from themselves directly
-  return values.map((value, index) => visit(value, parent, key, schema, addEntity));
+  return values.map((value, index) => visit(value, parent, key, schema, addEntity, visitedEntities));
 };
 
 export const denormalize = (schema, input, unvisit) => {
@@ -27,11 +27,11 @@ export const denormalize = (schema, input, unvisit) => {
 };
 
 export default class ArraySchema extends PolymorphicSchema {
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
     const values = getValues(input);
 
     return values
-      .map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity))
+      .map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity, visitedEntities))
       .filter((value) => value !== undefined && value !== null);
   }
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -48,12 +48,16 @@ export default class EntitySchema {
     return this._mergeStrategy(entityA, entityB);
   }
 
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
+    if (visitedEntities.has(input)) {
+      return this.getId(input, parent, key);
+    }
+    visitedEntities.add(input);
     const processedEntity = this._processStrategy(input, parent, key);
     Object.keys(this.schema).forEach((key) => {
       if (processedEntity.hasOwnProperty(key) && typeof processedEntity[key] === 'object') {
         const schema = this.schema[key];
-        processedEntity[key] = visit(processedEntity[key], processedEntity, key, schema, addEntity);
+        processedEntity[key] = visit(processedEntity[key], processedEntity, key, schema, addEntity, visitedEntities);
       }
     });
 

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -1,10 +1,10 @@
 import * as ImmutableUtils from './ImmutableUtils';
 
-export const normalize = (schema, input, parent, key, visit, addEntity) => {
+export const normalize = (schema, input, parent, key, visit, addEntity, visitedEntities) => {
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     const localSchema = schema[key];
-    const value = visit(input[key], input, key, localSchema, addEntity);
+    const value = visit(input[key], input, key, localSchema, addEntity, visitedEntities);
     if (value === undefined || value === null) {
       delete object[key];
     } else {

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -29,12 +29,12 @@ export default class PolymorphicSchema {
     return this.schema[attr];
   }
 
-  normalizeValue(value, parent, key, visit, addEntity) {
+  normalizeValue(value, parent, key, visit, addEntity, visitedEntities) {
     const schema = this.inferSchema(value, parent, key);
     if (!schema) {
       return value;
     }
-    const normalizedValue = visit(value, parent, key, schema, addEntity);
+    const normalizedValue = visit(value, parent, key, schema, addEntity, visitedEntities);
     return this.isSingleSchema || normalizedValue === undefined || normalizedValue === null
       ? normalizedValue
       : { id: normalizedValue, schema: this.getSchemaAttribute(value, parent, key) };

--- a/src/schemas/Union.js
+++ b/src/schemas/Union.js
@@ -8,8 +8,8 @@ export default class UnionSchema extends PolymorphicSchema {
     super(definition, schemaAttribute);
   }
 
-  normalize(input, parent, key, visit, addEntity) {
-    return this.normalizeValue(input, parent, key, visit, addEntity);
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
+    return this.normalizeValue(input, parent, key, visit, addEntity, visitedEntities);
   }
 
   denormalize(input, unvisit) {

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -1,13 +1,13 @@
 import PolymorphicSchema from './Polymorphic';
 
 export default class ValuesSchema extends PolymorphicSchema {
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
     return Object.keys(input).reduce((output, key, index) => {
       const value = input[key];
       return value !== undefined && value !== null
         ? {
             ...output,
-            [key]: this.normalizeValue(value, input, key, visit, addEntity)
+            [key]: this.normalizeValue(value, input, key, visit, addEntity, visitedEntities)
           }
         : output;
     }, {});


### PR DESCRIPTION
# Problem

Unable to normalize objects with circular references.  I get a `maximum call stack size exceeded` error. In my opinion since already normalizr supports denormalizing circular references, it makes sense to support normalizing circular references.

# Solution
If we have already normalized an entity, don't normalize it again in order to avoid infinite normalization loops.

I pass a `visitedEntities` set into all normalize functions.  In the entity normalize method I added the following logic: 
If an entity has already been normalized, don't normalize it and just return the id, 
else normalize the enitity and add the entity to the visitedEntities set


# notes
figure out why npm test works but npm run precommit brakes when I uncomment the second added test

# TODO
- [ ] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
