### PR TITLE
Merge with original definition for ValueSchemas aswell

### DIFF
--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -22,4 +22,11 @@ export default class ValuesSchema extends PolymorphicSchema {
       };
     }, {});
   }
+  
+  define(definition) {
+    this.schema = Object.keys(definition).reduce((entitySchema, key) => {
+      const schema = definition[key];
+      return { ...entitySchema, [key]: schema };
+    }, this.schema || {});
+  }
 }


### PR DESCRIPTION
Hey,

according to the docs ValueSchemas should also merge the definitions when calling `define()`.

I just copied the code from the ObjectSchema.