### PR TITLE
Add support for circular references

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -126,6 +126,22 @@ Object {
 }
 `;
 
+exports[`normalize normalizes entities with circular references 1`] = `
+Object {
+  "entities": Object {
+    "users": Object {
+      "123": Object {
+        "friends": Array [
+          123,
+        ],
+        "id": 123,
+      },
+    },
+  },
+  "result": 123,
+}
+`;
+
 exports[`normalize normalizes nested entities 1`] = `
 Object {
   "entities": Object {

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -18,6 +18,18 @@ describe('normalize', () => {
     expect(normalize([{ id: 1, type: 'foo' }, { id: 2, type: 'bar' }], [mySchema])).toMatchSnapshot();
   });
 
+  test('normalizes entities with circular references', () => {
+    const user = new schema.Entity('users');
+    user.define({
+      friends: [user]
+    });
+
+    const input = { id: 123, friends: [] };
+    input.friends.push(input);
+
+    expect(normalize(input, user)).toMatchSnapshot();
+  });
+
   test('normalizes nested entities', () => {
     const user = new schema.Entity('users');
     const comment = new schema.Entity('comments', {
@@ -81,11 +93,11 @@ describe('normalize', () => {
         return entity.uuid;
       }
 
-      normalize(input, parent, key, visit, addEntity) {
+      normalize(input, parent, key, visit, addEntity, visitedEntities) {
         const entity = { ...input };
         Object.keys(this.schema).forEach((key) => {
           const schema = this.schema[key];
-          entity[key] = visit(input[key], input, key, schema, addEntity);
+          entity[key] = visit(input[key], input, key, schema, addEntity, visitedEntities);
         });
         addEntity(this, entity, parent, key);
         return {

--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,17 @@ import ValuesSchema from './schemas/Values';
 import ArraySchema, * as ArrayUtils from './schemas/Array';
 import ObjectSchema, * as ObjectUtils from './schemas/Object';
 
-const visit = (value, parent, key, schema, addEntity) => {
+const visit = (value, parent, key, schema, addEntity, visitedEntities) => {
   if (typeof value !== 'object' || !value) {
     return value;
   }
 
   if (typeof schema === 'object' && (!schema.normalize || typeof schema.normalize !== 'function')) {
     const method = Array.isArray(schema) ? ArrayUtils.normalize : ObjectUtils.normalize;
-    return method(schema, value, parent, key, visit, addEntity);
+    return method(schema, value, parent, key, visit, addEntity, visitedEntities);
   }
 
-  return schema.normalize(value, parent, key, visit, addEntity);
+  return schema.normalize(value, parent, key, visit, addEntity, visitedEntities);
 };
 
 const addEntities = (entities) => (schema, processedEntity, value, parent, key) => {
@@ -48,8 +48,9 @@ export const normalize = (input, schema) => {
 
   const entities = {};
   const addEntity = addEntities(entities);
+  const visitedEntities = {};
 
-  const result = visit(input, input, null, schema, addEntity);
+  const result = visit(input, input, null, schema, addEntity, visitedEntities);
   return { entities, result };
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export const normalize = (input, schema) => {
 
   const entities = {};
   const addEntity = addEntities(entities);
-  const visitedEntities = {};
+  const visitedEntities = [];
 
   const result = visit(input, input, null, schema, addEntity, visitedEntities);
   return { entities, result };

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -11,14 +11,14 @@ const validateSchema = (definition) => {
 
 const getValues = (input) => (Array.isArray(input) ? input : Object.keys(input).map((key) => input[key]));
 
-export const normalize = (schema, input, parent, key, visit, addEntity) => {
+export const normalize = (schema, input, parent, key, visit, addEntity, visitedEntities) => {
   schema = validateSchema(schema);
 
   const values = getValues(input);
 
   // Special case: Arrays pass *their* parent on to their children, since there
   // is not any special information that can be gathered from themselves directly
-  return values.map((value, index) => visit(value, parent, key, schema, addEntity));
+  return values.map((value, index) => visit(value, parent, key, schema, addEntity, visitedEntities));
 };
 
 export const denormalize = (schema, input, unvisit) => {
@@ -27,11 +27,11 @@ export const denormalize = (schema, input, unvisit) => {
 };
 
 export default class ArraySchema extends PolymorphicSchema {
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
     const values = getValues(input);
 
     return values
-      .map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity))
+      .map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity, visitedEntities))
       .filter((value) => value !== undefined && value !== null);
   }
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -33,31 +33,6 @@ export default class EntitySchema {
     return this._idAttribute;
   }
 
-  stringifySafe(input) {
-    function replacer() {
-      const stack = [];
-      const keys = [];
-
-      return (key, value) => {
-        if (stack.length > 0) {
-          const thisPos = stack.indexOf(this);
-          ~thisPos ? stack.splice(thisPos + 1) : stack.push(this);
-          ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key);
-          if (~stack.indexOf(value)) {
-            value =
-              stack[0] === value ? '[Circular ~]' : `[Circular ~.${keys.slice(0, stack.indexOf(value)).join('.')}]`;
-          }
-        } else {
-          stack.push(value);
-        }
-
-        return value;
-      };
-    }
-
-    return JSON.stringify(input, replacer());
-  }
-
   define(definition) {
     this.schema = Object.keys(definition).reduce((entitySchema, key) => {
       const schema = definition[key];
@@ -74,11 +49,10 @@ export default class EntitySchema {
   }
 
   normalize(input, parent, key, visit, addEntity, visitedEntities) {
-    const stringifiedInput = this.stringifySafe(input);
-    if (visitedEntities[stringifiedInput]) {
+    if (visitedEntities.some((entity) => entity === input)) {
       return this.getId(input, parent, key);
     }
-    visitedEntities[stringifiedInput] = true;
+    visitedEntities.push(input);
 
     const processedEntity = this._processStrategy(input, parent, key);
     Object.keys(this.schema).forEach((key) => {

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -1,10 +1,10 @@
 import * as ImmutableUtils from './ImmutableUtils';
 
-export const normalize = (schema, input, parent, key, visit, addEntity) => {
+export const normalize = (schema, input, parent, key, visit, addEntity, visitedEntities) => {
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     const localSchema = schema[key];
-    const value = visit(input[key], input, key, localSchema, addEntity);
+    const value = visit(input[key], input, key, localSchema, addEntity, visitedEntities);
     if (value === undefined || value === null) {
       delete object[key];
     } else {

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -29,12 +29,12 @@ export default class PolymorphicSchema {
     return this.schema[attr];
   }
 
-  normalizeValue(value, parent, key, visit, addEntity) {
+  normalizeValue(value, parent, key, visit, addEntity, visitedEntities) {
     const schema = this.inferSchema(value, parent, key);
     if (!schema) {
       return value;
     }
-    const normalizedValue = visit(value, parent, key, schema, addEntity);
+    const normalizedValue = visit(value, parent, key, schema, addEntity, visitedEntities);
     return this.isSingleSchema || normalizedValue === undefined || normalizedValue === null
       ? normalizedValue
       : { id: normalizedValue, schema: this.getSchemaAttribute(value, parent, key) };

--- a/src/schemas/Union.js
+++ b/src/schemas/Union.js
@@ -8,8 +8,8 @@ export default class UnionSchema extends PolymorphicSchema {
     super(definition, schemaAttribute);
   }
 
-  normalize(input, parent, key, visit, addEntity) {
-    return this.normalizeValue(input, parent, key, visit, addEntity);
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
+    return this.normalizeValue(input, parent, key, visit, addEntity, visitedEntities);
   }
 
   denormalize(input, unvisit) {

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -1,13 +1,13 @@
 import PolymorphicSchema from './Polymorphic';
 
 export default class ValuesSchema extends PolymorphicSchema {
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, visitedEntities) {
     return Object.keys(input).reduce((output, key, index) => {
       const value = input[key];
       return value !== undefined && value !== null
         ? {
             ...output,
-            [key]: this.normalizeValue(value, input, key, visit, addEntity)
+            [key]: this.normalizeValue(value, input, key, visit, addEntity, visitedEntities)
           }
         : output;
     }, {});


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Unable to normalize inputs with circular references. I get a `maximum call stack size exceeded` error.

# Solution

This PR is based on https://github.com/paularmstrong/normalizr/pull/330 with a few changes (based on the fixes recommended there):

- Used `Array.prototype.some` for equality check instead of `Set` to avoid a polyfill
- Added tests using `toMatchSnapshot`

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
