### PR TITLE
Add possibility to use processedEntity with getId function

### DIFF
--- a/src/__tests__/__snapshots__/index.test.js.snap
+++ b/src/__tests__/__snapshots__/index.test.js.snap
@@ -209,6 +209,9 @@ Array [
       },
     },
     null,
+    Object {
+      "user": "456",
+    },
   ],
   Array [
     Object {
@@ -222,6 +225,64 @@ Array [
       },
     },
     null,
+    Object {
+      "user": "456",
+    },
+  ],
+]
+`;
+
+exports[`normalize uses the normalized input when getting the ID for an entity 1`] = `
+Object {
+  "entities": Object {
+    "recommendations": Object {
+      "undefined": Object {
+        "user": "456",
+      },
+    },
+    "users": Object {
+      "456": Object {
+        "id": 0,
+      },
+    },
+  },
+  "result": undefined,
+}
+`;
+
+exports[`normalize uses the normalized input when getting the ID for an entity 2`] = `
+Array [
+  Array [
+    Object {
+      "user": Object {
+        "id": "456",
+      },
+    },
+    Object {
+      "user": Object {
+        "id": "456",
+      },
+    },
+    null,
+    Object {
+      "user": "456",
+    },
+  ],
+  Array [
+    Object {
+      "user": Object {
+        "id": "456",
+      },
+    },
+    Object {
+      "user": Object {
+        "id": "456",
+      },
+    },
+    null,
+    Object {
+      "user": "456",
+    },
   ],
 ]
 `;

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -110,7 +110,25 @@ describe('normalize', () => {
 
   test('uses the non-normalized input when getting the ID for an entity', () => {
     const userEntity = new schema.Entity('users');
-    const idAttributeFn = jest.fn((nonNormalized, parent, key) => nonNormalized.user.id);
+    const idAttributeFn = jest.fn((nonNormalized, parent, key, processedEntity) => nonNormalized.user.id);
+    const recommendation = new schema.Entity(
+      'recommendations',
+      { user: userEntity },
+      {
+        idAttribute: idAttributeFn
+      }
+    );
+    expect(normalize({ user: { id: '456' } }, recommendation)).toMatchSnapshot();
+    expect(idAttributeFn.mock.calls).toMatchSnapshot();
+    expect(recommendation.idAttribute).toBe(idAttributeFn);
+  });
+
+  test('uses the normalized input when getting the ID for an entity', () => {
+    let identifier = 0;
+    const userEntity = new schema.Entity('users', undefined, {
+      processStrategy: (value) => ({ ...value, id: identifier++ })
+    });
+    const idAttributeFn = jest.fn((nonNormalized, parent, key, processedEntity) => processedEntity.user.id);
     const recommendation = new schema.Entity(
       'recommendations',
       { user: userEntity },

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const visit = (value, parent, key, schema, addEntity) => {
 
 const addEntities = (entities) => (schema, processedEntity, value, parent, key) => {
   const schemaKey = schema.key;
-  const id = schema.getId(value, parent, key);
+  const id = schema.getId(value, parent, key, processedEntity);
   if (!(schemaKey in entities)) {
     entities[schemaKey] = {};
   }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -40,8 +40,8 @@ export default class EntitySchema {
     }, this.schema || {});
   }
 
-  getId(input, parent, key) {
-    return this._getId(input, parent, key);
+  getId(input, parent, key, processedEntity) {
+    return this._getId(input, parent, key, processedEntity);
   }
 
   merge(entityA, entityB) {
@@ -58,7 +58,7 @@ export default class EntitySchema {
     });
 
     addEntity(this, processedEntity, input, parent, key);
-    return this.getId(input, parent, key);
+    return this.getId(input, parent, key, processedEntity);
   }
 
   denormalize(entity, unvisit) {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Add possibility to use processedEntity with function that is provided in idAttribute property. A necessity if one wants to create own custom ids that are not computable directly from the original entity.

# Solution

Add extra function property (processedEntity) to getId.

Related issue: #341 
