### PR TITLE
Fixed denormalization skipping of falsy valued ids used in `Object` schemas

### DIFF
--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -21,7 +21,7 @@ export const denormalize = (schema, input, unvisit) => {
 
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
-    if (object[key]) {
+    if (object[key] != null) {
       object[key] = unvisit(object[key], schema[key]);
     }
   });

--- a/src/schemas/__tests__/Object.test.js
+++ b/src/schemas/__tests__/Object.test.js
@@ -50,4 +50,19 @@ describe(`${schema.Object.name} denormalization`, () => {
     expect(denormalize({ user: 1 }, { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
     expect(denormalize(fromJS({ user: 1 }), { user: userSchema, tacos: {} }, fromJS(entities))).toMatchSnapshot();
   });
+
+  test('denormalizes an object that contains a property representing a an object with an id of zero', () => {
+    const userSchema = new schema.Entity('user');
+    const object = new schema.Object({
+      user: userSchema
+    });
+    const entities = {
+      user: {
+        0: { id: 0, name: 'Chancho' }
+      }
+    };
+    expect(denormalize({ user: 0 }, object, entities)).toMatchSnapshot();
+    expect(denormalize({ user: 0 }, object, fromJS(entities))).toMatchSnapshot();
+    expect(denormalize(fromJS({ user: 0 }), object, fromJS(entities))).toMatchSnapshot();
+  });
 });

--- a/src/schemas/__tests__/__snapshots__/Object.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Object.test.js.snap
@@ -27,6 +27,33 @@ Immutable.Map {
 }
 `;
 
+exports[`ObjectSchema denormalization denormalizes an object that contains a property representing a an object with an id of zero 1`] = `
+Object {
+  "user": Object {
+    "id": 0,
+    "name": "Chancho",
+  },
+}
+`;
+
+exports[`ObjectSchema denormalization denormalizes an object that contains a property representing a an object with an id of zero 2`] = `
+Object {
+  "user": Immutable.Map {
+    "id": 0,
+    "name": "Chancho",
+  },
+}
+`;
+
+exports[`ObjectSchema denormalization denormalizes an object that contains a property representing a an object with an id of zero 3`] = `
+Immutable.Map {
+  "user": Immutable.Map {
+    "id": 0,
+    "name": "Chancho",
+  },
+}
+`;
+
 exports[`ObjectSchema denormalization denormalizes plain object shorthand 1`] = `
 Object {
   "user": Object {


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Currently, if one has an `Object` schema that contains properties that are mapped to other entities, if the id of one of those mapped entities is `0` or some other falsy value, it will be skipped during denormalization. Seeing that `0` is not an uncommonly used id, it makes sense to allow non-null/non-undefined falsy values to be evaluated rather than skip them as if they were null or undefined.

Here is an example schema that would not currently allow a `categoryOwner` with an id of `0` to be denormalized, instead, denormalization of `categoryOwner` would be skipped and the value of `categoryOwner` would remain `0`:
```js
const userSchema = new schema.Entity('users');
const otherSchema = new schema.Entity('others', {
  categoryInfo: {
    categoryOwner: userSchema
  }
});
```



# Solution

The solution here was very simple. There is a check for see if an object's property evaluates to a falsy value; I simply changed this check from `if (object[key])` to `if (object[key] != null)` so that only `null` and `undefined` values would be skipped.

I also added a test to `Object.test.js` for the expected behavior.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
