### PR TITLE
Added jest config for node environment instead of the default (jsdom)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,20 @@
     "url": "https://github.com/paularmstrong/normalizr.git",
     "type": "git"
   },
-  "keywords": ["flux", "redux", "normalize", "denormalize", "api", "json"],
-  "files": ["dist/", "index.d.ts", "LICENSE", "README.md"],
+  "keywords": [
+    "flux",
+    "redux",
+    "normalize",
+    "denormalize",
+    "api",
+    "json"
+  ],
+  "files": [
+    "dist/",
+    "index.d.ts",
+    "LICENSE",
+    "README.md"
+  ],
   "main": "dist/normalizr.js",
   "module": "dist/normalizr.es.js",
   "typings": "index.d.ts",
@@ -32,7 +44,9 @@
     "test:coverage": "npm run test -- --coverage && cat ./coverage/lcov.info | coveralls"
   },
   "author": "Paul Armstrong",
-  "contributors": ["Dan Abramov"],
+  "contributors": [
+    "Dan Abramov"
+  ],
   "license": "MIT",
   "devDependencies": {
     "babel-core": "^6.26.0",
@@ -64,7 +78,16 @@
   },
   "dependencies": {},
   "lint-staged": {
-    "src/**/*.js": ["test", "git add"],
-    "*.{js,json,css,md}": ["prettier --write", "git add"]
+    "src/**/*.js": [
+      "test",
+      "git add"
+    ],
+    "*.{js,json,css,md}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }


### PR DESCRIPTION
# Problem

When installed with npm, the test produce the error: 

> SecurityError: localStorage is not available for opaque origins

caused by this issue https://github.com/facebook/jest/issues/6766

# Solution

Added jest config for node environment instead of the default (jsdom) in package.json.

# TODO

- [ ] Add || update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
