### PR TITLE
added a shared context object

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -3,11 +3,11 @@
 * [normalize](#normalizedata-schema)
 * [denormalize](#denormalizeinput-schema-entities)
 * [schema](#schema)
-  - [Array](#arraydefinition-schemaattribute)
-  - [Entity](#entitykey-definition---options--)
-  - [Object](#objectdefinition)
-  - [Union](#uniondefinition-schemaattribute)
-  - [Values](#valuesdefinition-schemaattribute)
+  * [Array](#arraydefinition-schemaattribute)
+  * [Entity](#entitykey-definition---options--)
+  * [Object](#objectdefinition)
+  * [Union](#uniondefinition-schemaattribute)
+  * [Values](#valuesdefinition-schemaattribute)
 
 ## `normalize(data, schema)`
 
@@ -21,9 +21,9 @@ Normalizes input data per the schema definition provided.
 ```js
 import { normalize, schema } from 'normalizr';
 
-const myData = { users: [ { id: 1 }, { id: 2 } ] };
+const myData = { users: [{ id: 1 }, { id: 2 }] };
 const user = new schema.Entity('users');
-const mySchema = { users: [ user ] }
+const mySchema = { users: [user] };
 const normalizedData = normalize(myData, mySchema);
 ```
 
@@ -45,11 +45,11 @@ const normalizedData = normalize(myData, mySchema);
 
 Denormalizes an input based on schema and provided entities from a plain object or Immutable data. The reverse of `normalize`.
 
-*Special Note:* Be careful with denormalization. Prematurely reverting your data to large, nested objects could cause performance impacts in React (and other) applications.
+_Special Note:_ Be careful with denormalization. Prematurely reverting your data to large, nested objects could cause performance impacts in React (and other) applications.
 
 If your schema and data have recursive references, only the first instance of an entity will be given. Subsequent references will be returned as the `id` provided.
 
-* `input`: **required** The normalized result that should be *de-normalized*. Usually the same value that was given in the `result` key of the output of `normalize`.
+* `input`: **required** The normalized result that should be _de-normalized_. Usually the same value that was given in the `result` key of the output of `normalize`.
 * `schema`: **required** A schema definition that was used to get the value for `input`.
 * `entities`: **required** An object, keyed by entity schema names that may appear in the denormalized output. Also accepts an object with Immutable data.
 
@@ -59,19 +59,16 @@ If your schema and data have recursive references, only the first instance of an
 import { denormalize, schema } from 'normalizr';
 
 const user = new schema.Entity('users');
-const mySchema = { users: [ user ] }
+const mySchema = { users: [user] };
 const entities = { users: { '1': { id: 1 }, '2': { id: 2 } } };
-const denormalizedData = denormalize({ users: [ 1, 2 ] }, mySchema, entities);
+const denormalizedData = denormalize({ users: [1, 2] }, mySchema, entities);
 ```
 
 ### Output
 
 ```js
-{ 
-  users: [
-    { id: 1 },
-    { id: 2 }
-  ]
+{
+  users: [{ id: 1 }, { id: 2 }];
 }
 ```
 
@@ -79,16 +76,15 @@ const denormalizedData = denormalize({ users: [ 1, 2 ] }, mySchema, entities);
 
 ### `Array(definition, schemaAttribute)`
 
-Creates a schema to normalize an array of entities. If the input value is an `Object` instead of an `Array`, the normalized result will be an `Array` of the `Object`'s values. 
+Creates a schema to normalize an array of entities. If the input value is an `Object` instead of an `Array`, the normalized result will be an `Array` of the `Object`'s values.
 
-*Note: The same behavior can be defined with shorthand syntax: `[ mySchema ]`*
+_Note: The same behavior can be defined with shorthand syntax: `[ mySchema ]`_
 
-* `definition`: **required** A singular schema that this array contains *or* a mapping of schema to attribute values.
-* `schemaAttribute`: *optional* (required if `definition` is not a singular schema) The attribute on each entity found that defines what schema, per the definition mapping, to use when normalizing.  
-Can be a string or a function. If given a function, accepts the following arguments:  
-    * `value`: The input value of the entity.
-    * `parent`: The parent object of the input array.
-    * `key`: The key at which the input array appears on the parent object.
+* `definition`: **required** A singular schema that this array contains _or_ a mapping of schema to attribute values.
+* `schemaAttribute`: _optional_ (required if `definition` is not a singular schema) The attribute on each entity found that defines what schema, per the definition mapping, to use when normalizing.  
+  Can be a string or a function. If given a function, accepts the following arguments:  
+   _ `value`: The input value of the entity.
+  _ `parent`: The parent object of the input array. \* `key`: The key at which the input array appears on the parent object.
 
 #### Instance Methods
 
@@ -99,12 +95,12 @@ Can be a string or a function. If given a function, accepts the following argume
 To describe a simple array of a singular entity type:
 
 ```js
-const data = [ { id: '123', name: 'Jim' }, { id: '456', name: 'Jane' } ];
+const data = [{ id: '123', name: 'Jim' }, { id: '456', name: 'Jane' }];
 const userSchema = new schema.Entity('users');
 
 const userListSchema = new schema.Array(userSchema);
 // or use shorthand syntax:
-const userListSchema = [ userSchema ];
+const userListSchema = [userSchema];
 
 const normalizedData = normalize(data, userListSchema);
 ```
@@ -123,21 +119,24 @@ const normalizedData = normalize(data, userListSchema);
 }
 ```
 
-If your input data is an array of more than one type of entity, it is necessary to define a schema mapping. 
+If your input data is an array of more than one type of entity, it is necessary to define a schema mapping.
 
-*Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created.*
+_Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created._
 
 For example:
 
 ```js
-const data = [ { id: 1, type: 'admin' }, { id: 2, type: 'user' } ];
+const data = [{ id: 1, type: 'admin' }, { id: 2, type: 'user' }];
 
 const userSchema = new schema.Entity('users');
 const adminSchema = new schema.Entity('admins');
-const myArray = new schema.Array({
-  admins: adminSchema,
-  users: userSchema
-}, (input, parent, key) => `${input.type}s`);
+const myArray = new schema.Array(
+  {
+    admins: adminSchema,
+    users: userSchema
+  },
+  (input, parent, key) => `${input.type}s`
+);
 
 const normalizedData = normalize(data, myArray);
 ```
@@ -161,21 +160,23 @@ const normalizedData = normalize(data, myArray);
 
 * `key`: **required** The key name under which all entities of this type will be listed in the normalized response. Must be a string name.
 * `definition`: A definition of the nested entities found within this entity. Defaults to empty object.  
-You *do not* need to define any keys in your entity other than those that hold nested entities. All other values will be copied to the normalized entity's output.
+  You _do not_ need to define any keys in your entity other than those that hold nested entities. All other values will be copied to the normalized entity's output.
 * `options`:
-    - `idAttribute`: The attribute where unique IDs for each of this entity type can be found.  
+  * `idAttribute`: The attribute where unique IDs for each of this entity type can be found.  
     Accepts either a string `key` or a function that returns the IDs `value`. Defaults to `'id'`.  
-    As a function, accepts the following arguments, in order: 
-      * `value`: The input value of the entity.
-      * `parent`: The parent object of the input array.
-      * `key`: The key at which the input array appears on the parent object.
-    - `mergeStrategy(entityA, entityB)`: Strategy to use when merging two entities with the same `id` value. Defaults to merge the more recently found entity onto the previous.
-    - `processStrategy(value, parent, key)`: Strategy to use when pre-processing the entity. Use this method to add extra data, defaults, and/or completely change the entity before normalization is complete. Defaults to returning a shallow copy of the input entity.  
-    *Note: It is recommended to always return a copy of your input and not modify the original.*  
-    The function accepts the following arguments, in order: 
-      * `value`: The input value of the entity.
-      * `parent`: The parent object of the input array.
-      * `key`: The key at which the input array appears on the parent object.
+    As a function, accepts the following arguments, in order:
+    * `value`: The input value of the entity.
+    * `parent`: The parent object of the input array.
+    * `key`: The key at which the input array appears on the parent object.
+  * `mergeStrategy(entityA, entityB)`: Strategy to use when merging two entities with the same `id` value. Defaults to merge the more recently found entity onto the previous.
+  * `processStrategy(value, parent, key, context)`: Strategy to use when pre-processing the entity. Use this method to add extra data, defaults, and/or completely change the entity before normalization is complete. Defaults to returning a shallow copy of the input entity.
+    _Note: It is recommended to always return a copy of your input and not modify the original._  
+    The function accepts the following arguments, in order:
+    * `value`: The input value of the entity.
+    * `parent`: The parent object of the input array.
+    * `key`: The key at which the input array appears on the parent object.
+    * `context`: A shared object create once per normalization.
+    * `context.entities`: The entity object being built.
 
 #### Instance Methods
 
@@ -192,7 +193,10 @@ You *do not* need to define any keys in your entity other than those that hold n
 const data = { id_str: '123', url: 'https://twitter.com', user: { id_str: '456', name: 'Jimmy' } };
 
 const user = new schema.Entity('users', {}, { idAttribute: 'id_str' });
-const tweet = new schema.Entity('tweets', { user: user }, { 
+const tweet = new schema.Entity(
+  'tweets',
+  { user: user },
+  {
     idAttribute: 'id_str',
     // Apply everything from entityB over entityA, except for "favorites"
     mergeStrategy: (entityA, entityB) => ({
@@ -202,7 +206,8 @@ const tweet = new schema.Entity('tweets', { user: user }, {
     }),
     // Remove the URL field from the entity
     processStrategy: (entity) => omit(entity, 'url')
-});
+  }
+);
 
 const normalizedData = normalize(data, tweet);
 ```
@@ -221,19 +226,16 @@ const normalizedData = normalize(data, tweet);
 
 #### `idAttribute` Usage
 
-When passing the `idAttribute` a function, it should return the IDs value. 
+When passing the `idAttribute` a function, it should return the IDs value.
 
 For Example:
 
 ```js
-const data = [
-    { id: '1', guest_id: null, name: 'Esther' },
-    { id: '1', guest_id: '22', name: 'Tom' },
-];
+const data = [{ id: '1', guest_id: null, name: 'Esther' }, { id: '1', guest_id: '22', name: 'Tom' }];
 
 const patronsSchema = new schema.Entity('patrons', undefined, {
   // idAttribute *functions* must return the ids **value** (not key)
-  idAttribute: value => value.guest_id ? `${value.id}-${value.guest_id}` : value.id,
+  idAttribute: (value) => (value.guest_id ? `${value.id}-${value.guest_id}` : value.id)
 });
 
 normalize(data, [patronsSchema]);
@@ -253,13 +255,12 @@ normalize(data, [patronsSchema]);
 }
 ```
 
-
 ### `Object(definition)`
 
-Define a plain object mapping that has values needing to be normalized into Entities. *Note: The same behavior can be defined with shorthand syntax: `{ ... }`*
+Define a plain object mapping that has values needing to be normalized into Entities. _Note: The same behavior can be defined with shorthand syntax: `{ ... }`_
 
 * `definition`: **required** A definition of the nested entities found within this object. Defaults to empty object.  
-You *do not* need to define any keys in your object other than those that hold other entities. All other values will be copied to the normalized output.
+  You _do not_ need to define any keys in your object other than those that hold other entities. All other values will be copied to the normalized output.
 
 #### Instance Methods
 
@@ -269,7 +270,7 @@ You *do not* need to define any keys in your object other than those that hold o
 
 ```js
 // Example data response
-const data = { users: [ { id: '123', name: 'Beth' } ] };
+const data = { users: [{ id: '123', name: 'Beth' }] };
 
 const user = new schema.Entity('users');
 const responseSchema = new schema.Object({ users: new schema.Array(user) });
@@ -296,7 +297,7 @@ Describe a schema which is a union of multiple schemas. This is useful if you ne
 
 * `definition`: **required** An object mapping the definition of the nested entities found within the input array
 * `schemaAttribute`: **required** The attribute on each entity found that defines what schema, per the definition mapping, to use when normalizing.  
-Can be a string or a function. If given a function, accepts the following arguments:  
+  Can be a string or a function. If given a function, accepts the following arguments:
   * `value`: The input value of the entity.
   * `parent`: The parent object of the input array.
   * `key`: The key at which the input array appears on the parent object.
@@ -307,17 +308,20 @@ Can be a string or a function. If given a function, accepts the following argume
 
 #### Usage
 
-*Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created.*
+_Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created._
 
 ```js
 const data = { owner: { id: 1, type: 'user', name: 'Anne' } };
 
 const user = new schema.Entity('users');
 const group = new schema.Entity('groups');
-const unionSchema = new schema.Union({
-  user: user,
-  group: group
-}, 'type');
+const unionSchema = new schema.Union(
+  {
+    user: user,
+    group: group
+  },
+  'type'
+);
 
 const normalizedData = normalize(data, { owner: unionSchema });
 ```
@@ -337,9 +341,9 @@ const normalizedData = normalize(data, { owner: unionSchema });
 
 Describes a map whose values follow the given schema.
 
-* `definition`: **required** A singular schema that this array contains *or* a mapping of schema to attribute values.
-* `schemaAttribute`: *optional* (required if `definition` is not a singular schema) The attribute on each entity found that defines what schema, per the definition mapping, to use when normalizing.  
-Can be a string or a function. If given a function, accepts the following arguments:  
+* `definition`: **required** A singular schema that this array contains _or_ a mapping of schema to attribute values.
+* `schemaAttribute`: _optional_ (required if `definition` is not a singular schema) The attribute on each entity found that defines what schema, per the definition mapping, to use when normalizing.  
+  Can be a string or a function. If given a function, accepts the following arguments:
   * `value`: The input value of the entity.
   * `parent`: The parent object of the input array.
   * `key`: The key at which the input array appears on the parent object.
@@ -372,22 +376,25 @@ const normalizedData = normalize(data, valuesSchema);
 
 If your input data is an object that has values of more than one type of entity, but their schema is not easily defined by the key, you can use a mapping of schema, much like `schema.Union` and `schema.Array`.
 
-*Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created.*
+_Note: If your data returns an object that you did not provide a mapping for, the original object will be returned in the result and an entity will not be created._
 
 For example:
 
 ```js
 const data = {
-  '1': { id: 1, type: 'admin' }, 
+  '1': { id: 1, type: 'admin' },
   '2': { id: 2, type: 'user' }
 };
 
 const userSchema = new schema.Entity('users');
 const adminSchema = new schema.Entity('admins');
-const valuesSchema = new schema.Values({
-  admins: adminSchema,
-  users: userSchema
-}, (input, parent, key) => `${input.type}s`);
+const valuesSchema = new schema.Values(
+  {
+    admins: adminSchema,
+    users: userSchema
+  },
+  (input, parent, key) => `${input.type}s`
+);
 
 const normalizedData = normalize(data, valuesSchema);
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,17 @@ import ValuesSchema from './schemas/Values';
 import ArraySchema, * as ArrayUtils from './schemas/Array';
 import ObjectSchema, * as ObjectUtils from './schemas/Object';
 
-const visit = (value, parent, key, schema, addEntity) => {
+const visit = (value, parent, key, schema, addEntity, context) => {
   if (typeof value !== 'object' || !value) {
     return value;
   }
 
   if (typeof schema === 'object' && (!schema.normalize || typeof schema.normalize !== 'function')) {
     const method = Array.isArray(schema) ? ArrayUtils.normalize : ObjectUtils.normalize;
-    return method(schema, value, parent, key, visit, addEntity);
+    return method(schema, value, parent, key, visit, addEntity, context);
   }
 
-  return schema.normalize(value, parent, key, visit, addEntity);
+  return schema.normalize(value, parent, key, visit, addEntity, context);
 };
 
 const addEntities = (entities) => (schema, processedEntity, value, parent, key) => {
@@ -47,9 +47,10 @@ export const normalize = (input, schema) => {
   }
 
   const entities = {};
+  const context = { entities };
   const addEntity = addEntities(entities);
 
-  const result = visit(input, input, null, schema, addEntity);
+  const result = visit(input, input, null, schema, addEntity, context);
   return { entities, result };
 };
 

--- a/src/schemas/Array.js
+++ b/src/schemas/Array.js
@@ -11,14 +11,14 @@ const validateSchema = (definition) => {
 
 const getValues = (input) => (Array.isArray(input) ? input : Object.keys(input).map((key) => input[key]));
 
-export const normalize = (schema, input, parent, key, visit, addEntity) => {
+export const normalize = (schema, input, parent, key, visit, addEntity, context) => {
   schema = validateSchema(schema);
 
   const values = getValues(input);
 
   // Special case: Arrays pass *their* parent on to their children, since there
   // is not any special information that can be gathered from themselves directly
-  return values.map((value, index) => visit(value, parent, key, schema, addEntity));
+  return values.map((value, index) => visit(value, parent, key, schema, addEntity, context));
 };
 
 export const denormalize = (schema, input, unvisit) => {
@@ -27,11 +27,11 @@ export const denormalize = (schema, input, unvisit) => {
 };
 
 export default class ArraySchema extends PolymorphicSchema {
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, context) {
     const values = getValues(input);
 
     return values
-      .map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity))
+      .map((value, index) => this.normalizeValue(value, parent, key, visit, addEntity, context))
       .filter((value) => value !== undefined && value !== null);
   }
 

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -48,12 +48,12 @@ export default class EntitySchema {
     return this._mergeStrategy(entityA, entityB);
   }
 
-  normalize(input, parent, key, visit, addEntity) {
-    const processedEntity = this._processStrategy(input, parent, key);
+  normalize(input, parent, key, visit, addEntity, context) {
+    const processedEntity = this._processStrategy(input, parent, key, context);
     Object.keys(this.schema).forEach((key) => {
       if (processedEntity.hasOwnProperty(key) && typeof processedEntity[key] === 'object') {
         const schema = this.schema[key];
-        processedEntity[key] = visit(processedEntity[key], processedEntity, key, schema, addEntity);
+        processedEntity[key] = visit(processedEntity[key], processedEntity, key, schema, addEntity, context);
       }
     });
 

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -1,10 +1,10 @@
 import * as ImmutableUtils from './ImmutableUtils';
 
-export const normalize = (schema, input, parent, key, visit, addEntity) => {
+export const normalize = (schema, input, parent, key, visit, addEntity, context) => {
   const object = { ...input };
   Object.keys(schema).forEach((key) => {
     const localSchema = schema[key];
-    const value = visit(input[key], input, key, localSchema, addEntity);
+    const value = visit(input[key], input, key, localSchema, addEntity, context);
     if (value === undefined || value === null) {
       delete object[key];
     } else {

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -29,12 +29,12 @@ export default class PolymorphicSchema {
     return this.schema[attr];
   }
 
-  normalizeValue(value, parent, key, visit, addEntity) {
+  normalizeValue(value, parent, key, visit, addEntity, context) {
     const schema = this.inferSchema(value, parent, key);
     if (!schema) {
       return value;
     }
-    const normalizedValue = visit(value, parent, key, schema, addEntity);
+    const normalizedValue = visit(value, parent, key, schema, addEntity, context);
     return this.isSingleSchema || normalizedValue === undefined || normalizedValue === null
       ? normalizedValue
       : { id: normalizedValue, schema: this.getSchemaAttribute(value, parent, key) };

--- a/src/schemas/Union.js
+++ b/src/schemas/Union.js
@@ -8,8 +8,8 @@ export default class UnionSchema extends PolymorphicSchema {
     super(definition, schemaAttribute);
   }
 
-  normalize(input, parent, key, visit, addEntity) {
-    return this.normalizeValue(input, parent, key, visit, addEntity);
+  normalize(input, parent, key, visit, addEntity, context) {
+    return this.normalizeValue(input, parent, key, visit, addEntity, context);
   }
 
   denormalize(input, unvisit) {

--- a/src/schemas/Values.js
+++ b/src/schemas/Values.js
@@ -1,13 +1,13 @@
 import PolymorphicSchema from './Polymorphic';
 
 export default class ValuesSchema extends PolymorphicSchema {
-  normalize(input, parent, key, visit, addEntity) {
+  normalize(input, parent, key, visit, addEntity, context) {
     return Object.keys(input).reduce((output, key, index) => {
       const value = input[key];
       return value !== undefined && value !== null
         ? {
             ...output,
-            [key]: this.normalizeValue(value, input, key, visit, addEntity)
+            [key]: this.normalizeValue(value, input, key, visit, addEntity, context)
           }
         : output;
     }, {});

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -113,6 +113,28 @@ describe(`${schema.Entity.name} normalization`, () => {
 
       expect(normalize({ message: { id: '123', data: { attachment: { id: '456' } } } }, myEntity)).toMatchSnapshot();
     });
+
+    test('has a shared context', () => {
+      let lastContext;
+      const processStrategy = (input, parent, key, context) => {
+        if (lastContext) {
+          expect(lastContext).toBe(context);
+        }
+        lastContext = context;
+        return { ...input };
+      };
+      const attachmentEntity = new schema.Entity('attachments', {}, { processStrategy });
+      // If not run before, this schema would require a parent object with key "message"
+      const myEntity = new schema.Entity(
+        'entries',
+        {
+          data: { attachment: attachmentEntity }
+        },
+        { idAttribute: (input) => values(input)[0].id, processStrategy }
+      );
+
+      normalize({ message: { id: '123', data: { attachment: { id: '456' } } } }, { message: myEntity });
+    });
   });
 });
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

I need a shared state between processStrategy calls to check for circular dependencies.

# Solution

Adding an optional fourth parameter (context) gives me access to a shared object I can use to add arrays of seen objects, etc. The context object also contains the current accumulating entities object by default.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
