### PR TITLE
[minor] Improve typescript types with generics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,59 +1,62 @@
 declare namespace schema {
-  export type StrategyFunction = (value: any, parent: any, key: string) => any;
+  export type StrategyFunction<T> = (value: any, parent: any, key: string) => T;
   export type SchemaFunction = (value: any, parent: any, key: string) => string;
   export type MergeFunction = (entityA: any, entityB: any) => any;
 
-  export class Array {
-    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
+  export class Array<T = any> {
+    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }
 
-  export interface EntityOptions {
+  export interface EntityOptions<T = any> {
     idAttribute?: string | SchemaFunction
     mergeStrategy?: MergeFunction
-    processStrategy?: StrategyFunction
+    processStrategy?: StrategyFunction<T>
   }
 
-  export class Entity {
-    constructor(key: string | symbol, definition?: Schema, options?: EntityOptions)
+  export class Entity<T = any> {
+    constructor(key: string | symbol, definition?: Schema, options?: EntityOptions<T>)
     define(definition: Schema): void
     key: string
+    getId: SchemaFunction
+    _processStrategy: StrategyFunction<T>
   }
 
-  export class Object {
-    constructor(definition: {[key: string]: Schema})
+  export class Object<T = any> {
+    constructor(definition: {[key: string]: Schema<T>})
     define(definition: Schema): void
   }
 
-  export class Union {
-    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
+  export class Union<T = any> {
+    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }
 
-  export class Values {
-    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
+  export class Values<T = any> {
+    constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }
 }
 
-export type Schema =
-  schema.Array |
-  schema.Entity |
-  schema.Object |
-  schema.Union |
-  schema.Values |
-  schema.Array[] |
-  schema.Entity[] |
-  schema.Object[] |
-  schema.Union[] |
-  schema.Values[] |
-  {[key: string]: Schema | Schema[]};
+export type Schema<T = any> =
+  | schema.Entity<T>
+  | schema.Object<T>
+  | schema.Union<T>
+  | schema.Values<T>
+  | SchemaObject<T>
+  | SchemaArray<T>;
+
+export interface SchemaObject<T> {
+  [key: string]: Schema<T>
+}
+
+export interface SchemaArray<T> extends Array<Schema<T>> {}
 
 export type NormalizedSchema<E, R> = { entities: E, result: R };
 
-export function normalize<E = any, R = any>(
+export function normalize<T = any, E = { [key:string]: { [key:string]: T }}, R = any>(
   data: any,
-  schema: Schema
+  schema: Schema<T>
 ): NormalizedSchema<E, R>;
 
 export function denormalize(


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem
It's very hard to infer anything about the types without generics. Given that it's most useful to have types for the data stored in your normalized cache this seems pretty essential.

# Solution
The idea here is at some point you'll point to an entity whose processStrategy will return the type you expect.

Splitting the Schema union type was essential to distinguish between list results and singular results as well.

In the end I was able to create my own type in userland that could extract what type to expect:
```typescript
export type SchemaOf<T> = T extends SchemaArray<infer R>
  ? R[]
  : T extends SchemaBase<infer R>
    ? R
    : never;
```

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
