### PR TITLE
Added BaseSchema for typesafe schema walking

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3,65 +3,58 @@ declare namespace schema {
   export type SchemaFunction = (value: any, parent: any, key: string) => string;
   export type MergeFunction = (entityA: any, entityB: any) => any;
 
-  export class Array extends BaseSchema {
-    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
-    define(definition: Schema): void
+  export class Array implements BaseSchema {
+    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction);
+    define(definition: Schema): void;
   }
 
   export interface EntityOptions {
-    idAttribute?: string | SchemaFunction
-    mergeStrategy?: MergeFunction
-    processStrategy?: StrategyFunction
+    idAttribute?: string | SchemaFunction;
+    mergeStrategy?: MergeFunction;
+    processStrategy?: StrategyFunction;
   }
 
   export interface BaseSchema {
     schema: Schema;
   }
 
-  export class Entity extends BaseSchema {
-    constructor(key: string, definition?: Schema, options?: EntityOptions)
-    define(definition: Schema): void
-    key: string
+  export class Entity implements BaseSchema {
+    constructor(key: string, definition?: Schema, options?: EntityOptions);
+    define(definition: Schema): void;
+    key: string;
   }
 
-  export class Object extends BaseSchema {
-    constructor(definition: {[key: string]: Schema})
-    define(definition: Schema): void
+  export class Object implements BaseSchema {
+    constructor(definition: { [key: string]: Schema });
+    define(definition: Schema): void;
   }
 
-  export class Union extends BaseSchema {
-    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
-    define(definition: Schema): void
+  export class Union implements BaseSchema {
+    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction);
+    define(definition: Schema): void;
   }
 
-  export class Values extends BaseSchema {
-    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
-    define(definition: Schema): void
+  export class Values implements BaseSchema {
+    constructor(definition: Schema, schemaAttribute?: string | SchemaFunction);
+    define(definition: Schema): void;
   }
 }
 
 export type Schema =
-  schema.Array |
-  schema.Entity |
-  schema.Object |
-  schema.Union |
-  schema.Values |
-  schema.Array[] |
-  schema.Entity[] |
-  schema.Object[] |
-  schema.Union[] |
-  schema.Values[] |
-  {[key: string]: Schema | Schema[]};
+  | schema.Array
+  | schema.Entity
+  | schema.Object
+  | schema.Union
+  | schema.Values
+  | schema.Array[]
+  | schema.Entity[]
+  | schema.Object[]
+  | schema.Union[]
+  | schema.Values[]
+  | { [key: string]: Schema | Schema[] };
 
-export type NormalizedSchema<E, R> = { entities: E, result: R };
+export type NormalizedSchema<E, R> = { entities: E; result: R };
 
-export function normalize<E = any, R = any>(
-  data: any,
-  schema: Schema
-): NormalizedSchema<E, R>;
+export function normalize<E = any, R = any>(data: any, schema: Schema): NormalizedSchema<E, R>;
 
-export function denormalize(
-  input: any,
-  schema: Schema,
-  entities: any
-): any;
+export function denormalize(input: any, schema: Schema, entities: any): any;

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare namespace schema {
   export type SchemaFunction = (value: any, parent: any, key: string) => string;
   export type MergeFunction = (entityA: any, entityB: any) => any;
 
-  export class Array {
+  export class Array extends BaseSchema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }
@@ -14,23 +14,27 @@ declare namespace schema {
     processStrategy?: StrategyFunction
   }
 
-  export class Entity {
+  export interface BaseSchema {
+    schema: Schema;
+  }
+
+  export class Entity extends BaseSchema {
     constructor(key: string, definition?: Schema, options?: EntityOptions)
     define(definition: Schema): void
     key: string
   }
 
-  export class Object {
+  export class Object extends BaseSchema {
     constructor(definition: {[key: string]: Schema})
     define(definition: Schema): void
   }
 
-  export class Union {
+  export class Union extends BaseSchema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }
 
-  export class Values {
+  export class Values extends BaseSchema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction)
     define(definition: Schema): void
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare namespace schema {
   export class Array implements BaseSchema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction);
     define(definition: Schema): void;
+    schema: Schema;
   }
 
   export interface EntityOptions {
@@ -22,21 +23,25 @@ declare namespace schema {
     constructor(key: string, definition?: Schema, options?: EntityOptions);
     define(definition: Schema): void;
     key: string;
+    schema: Schema;
   }
 
   export class Object implements BaseSchema {
     constructor(definition: { [key: string]: Schema });
     define(definition: Schema): void;
+    schema: Schema;
   }
 
   export class Union implements BaseSchema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction);
     define(definition: Schema): void;
+    schema: Schema;
   }
 
   export class Values implements BaseSchema {
     constructor(definition: Schema, schemaAttribute?: string | SchemaFunction);
     define(definition: Schema): void;
+    schema: Schema;
   }
 }
 

--- a/src/schemas/BaseSchema.js
+++ b/src/schemas/BaseSchema.js
@@ -1,3 +1,3 @@
 export default class BaseSchema {
-    schema = undefined;
+    schema;
 }

--- a/src/schemas/BaseSchema.js
+++ b/src/schemas/BaseSchema.js
@@ -1,0 +1,3 @@
+export default class BaseSchema {
+    schema = undefined;
+}

--- a/src/schemas/BaseSchema.js
+++ b/src/schemas/BaseSchema.js
@@ -1,3 +1,3 @@
 export default class BaseSchema {
-    schema;
+  schema;
 }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -6,6 +6,7 @@ const getDefaultGetId = (idAttribute) => (input) =>
 
 export default class EntitySchema extends BaseSchema {
   constructor(key, definition = {}, options = {}) {
+    super();
     if (!key || typeof key !== 'string') {
       throw new Error(`Expected a string key for Entity, but found ${key}.`);
     }

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -1,9 +1,10 @@
 import * as ImmutableUtils from './ImmutableUtils';
+import BaseSchema from './BaseSchema';
 
 const getDefaultGetId = (idAttribute) => (input) =>
   ImmutableUtils.isImmutable(input) ? input.get(idAttribute) : input[idAttribute];
 
-export default class EntitySchema {
+export default class EntitySchema extends BaseSchema {
   constructor(key, definition = {}, options = {}) {
     if (!key || typeof key !== 'string') {
       throw new Error(`Expected a string key for Entity, but found ${key}.`);

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -31,6 +31,7 @@ export const denormalize = (schema, input, unvisit) => {
 
 export default class ObjectSchema extends BaseSchema {
   constructor(definition) {
+    super();
     this.define(definition);
   }
 

--- a/src/schemas/Object.js
+++ b/src/schemas/Object.js
@@ -1,4 +1,5 @@
 import * as ImmutableUtils from './ImmutableUtils';
+import BaseSchema from './BaseSchema';
 
 export const normalize = (schema, input, parent, key, visit, addEntity, visitedEntities) => {
   const object = { ...input };
@@ -28,7 +29,7 @@ export const denormalize = (schema, input, unvisit) => {
   return object;
 };
 
-export default class ObjectSchema {
+export default class ObjectSchema extends BaseSchema {
   constructor(definition) {
     this.define(definition);
   }

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -3,6 +3,7 @@ import BaseSchema from './BaseSchema';
 
 export default class PolymorphicSchema extends BaseSchema {
   constructor(definition, schemaAttribute) {
+    super();
     if (schemaAttribute) {
       this._schemaAttribute = typeof schemaAttribute === 'string' ? (input) => input[schemaAttribute] : schemaAttribute;
     }

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -1,6 +1,7 @@
 import { isImmutable } from './ImmutableUtils';
+import BaseSchema from './BaseSchema';
 
-export default class PolymorphicSchema {
+export default class PolymorphicSchema extends BaseSchema {
   constructor(definition, schemaAttribute) {
     if (schemaAttribute) {
       this._schemaAttribute = typeof schemaAttribute === 'string' ? (input) => input[schemaAttribute] : schemaAttribute;

--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -1,5 +1,5 @@
-import { isImmutable } from './ImmutableUtils';
 import BaseSchema from './BaseSchema';
+import { isImmutable } from './ImmutableUtils';
 
 export default class PolymorphicSchema extends BaseSchema {
   constructor(definition, schemaAttribute) {


### PR DESCRIPTION
# Problem
If you try to iterate through Schemas in other software projects you end up doing `(schema as any).schema` because its not defined in the class.

# Solution
Add schema to the class