### PR TITLE
fix(schemas): don't use schema to attribute mapping on singular array schemas

### DIFF
--- a/src/schemas/Polymorphic.js
+++ b/src/schemas/Polymorphic.js
@@ -45,7 +45,7 @@ export default class PolymorphicSchema {
     if (!this.isSingleSchema && !schemaKey) {
       return value;
     }
-    const id = isImmutable(value) ? value.get('id') : value.id;
+    const id = this.isSingleSchema ? undefined : isImmutable(value) ? value.get('id') : value.id;
     const schema = this.isSingleSchema ? this.schema : this.schema[schemaKey];
     return unvisit(id || value, schema);
   }

--- a/src/schemas/__tests__/Array.test.js
+++ b/src/schemas/__tests__/Array.test.js
@@ -192,5 +192,17 @@ describe(`${schema.Array.name} denormalization`, () => {
       expect(denormalize('123', taco, entities)).toMatchSnapshot();
       expect(denormalize('123', taco, fromJS(entities))).toMatchSnapshot();
     });
+
+    test('does not assume mapping of schema to attribute values when schemaAttribute is not set', () => {
+      const cats = new schema.Entity('cats');
+      const catRecord = new schema.Object({
+        cat: cats
+      });
+      const catList = new schema.Array(catRecord);
+      const input = [{ cat: { id: 1 }, id: 5 }, { cat: { id: 2 }, id: 6 }];
+      const output = normalize(input, catList);
+      expect(output).toMatchSnapshot();
+      expect(denormalize(output.result, catList, output.entities)).toEqual(input);
+    });
   });
 });

--- a/src/schemas/__tests__/__snapshots__/Array.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Array.test.js.snap
@@ -66,6 +66,31 @@ Array [
 ]
 `;
 
+exports[`ArraySchema denormalization Class does not assume mapping of schema to attribute values when schemaAttribute is not set 1`] = `
+Object {
+  "entities": Object {
+    "cats": Object {
+      "1": Object {
+        "id": 1,
+      },
+      "2": Object {
+        "id": 2,
+      },
+    },
+  },
+  "result": Array [
+    Object {
+      "cat": 1,
+      "id": 5,
+    },
+    Object {
+      "cat": 2,
+      "id": 6,
+    },
+  ],
+}
+`;
+
 exports[`ArraySchema denormalization Class returns the input value if is not an array 1`] = `
 Object {
   "fillings": Object {},


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

Denormalization does not seem to produce the correct result when a singular Array schema owns an Object schema whose instances own an `id` property. 

For example:

```javascript
const cats = new schema.Entity('cats');
// catRecord instances own an `id` property
const catRecord = new schema.Object({
   cat: cats
});
const catList = new schema.Array(catRecord);
```

The problem is in the the `denormalizeValue` method of the `Polymorphic` class.

When the value to be unvisited owns a property named `id`, then this method uses the value of the `id` property as the input value for the call to `unvisit` in place of the value itself, which is not the case on singular Array schema, where the value itself should always be used instead.

# Solution

I've added a guard which prevents the value of the `id` property to become the input to `unvisit` when the current schema is a singular schema.

# TODO

- [ x] Add & update tests
- [ x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
