### PR TITLE
[fix] When normalize() receives null input, don't say it is an object

### DIFF
--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -12,6 +12,11 @@ describe('normalize', () => {
     expect(() => normalize({})).toThrow();
   });
 
+  test('cannot normalize with null input', () => {
+    const mySchema = new schema.Entity('tacos');
+    expect(() => normalize(null, mySchema)).toThrow(/null/);
+  });
+
   test('normalizes entities', () => {
     const mySchema = new schema.Entity('tacos');
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,9 @@ export const schema = {
 export const normalize = (input, schema) => {
   if (!input || typeof input !== 'object') {
     throw new Error(
-      `Unexpected input given to normalize. Expected type to be "object", found "${input && typeof input}".`
+      `Unexpected input given to normalize. Expected type to be "object", found "${
+        input === null ? 'null' : typeof input
+      }".`
     );
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,9 @@ export const schema = {
 
 export const normalize = (input, schema) => {
   if (!input || typeof input !== 'object') {
-    throw new Error(`Unexpected input given to normalize. Expected type to be "object", found "${typeof input}".`);
+    throw new Error(
+      `Unexpected input given to normalize. Expected type to be "object", found "${input && typeof input}".`
+    );
   }
 
   const entities = {};


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem
In Javascript typeof null === 'object'. 

# Solution

Since the check in normalize includes one for !input, it should say 'found null' when null is passed rather than a confusing message that it found object when it needed object.

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
