### PR TITLE
Improve performance of circular reference detection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ export const normalize = (input, schema) => {
 
   const entities = {};
   const addEntity = addEntities(entities);
-  const visitedEntities = [];
+  const visitedEntities = {};
 
   const result = visit(input, input, null, schema, addEntity, visitedEntities);
   return { entities, result };

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -49,10 +49,15 @@ export default class EntitySchema {
   }
 
   normalize(input, parent, key, visit, addEntity, visitedEntities) {
-    if (visitedEntities.some((entity) => entity === input)) {
-      return this.getId(input, parent, key);
+    const id = this.getId(input, parent, key);
+
+    if (!(id in visitedEntities)) {
+      visitedEntities[id] = [];
     }
-    visitedEntities.push(input);
+    if (visitedEntities[id].some((entity) => entity === input)) {
+      return id;
+    }
+    visitedEntities[id].push(input);
 
     const processedEntity = this._processStrategy(input, parent, key);
     Object.keys(this.schema).forEach((key) => {
@@ -63,7 +68,7 @@ export default class EntitySchema {
     });
 
     addEntity(this, processedEntity, input, parent, key);
-    return this.getId(input, parent, key);
+    return id;
   }
 
   denormalize(entity, unvisit) {

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -50,14 +50,18 @@ export default class EntitySchema {
 
   normalize(input, parent, key, visit, addEntity, visitedEntities) {
     const id = this.getId(input, parent, key);
+    const entityType = this.key;
 
-    if (!(id in visitedEntities)) {
-      visitedEntities[id] = [];
+    if (!(entityType in visitedEntities)) {
+      visitedEntities[entityType] = {};
     }
-    if (visitedEntities[id].some((entity) => entity === input)) {
+    if (!(id in visitedEntities[entityType])) {
+      visitedEntities[entityType][id] = [];
+    }
+    if (visitedEntities[entityType][id].some((entity) => entity === input)) {
       return id;
     }
-    visitedEntities[id].push(input);
+    visitedEntities[entityType][id].push(input);
 
     const processedEntity = this._processStrategy(input, parent, key);
     Object.keys(this.schema).forEach((key) => {


### PR DESCRIPTION
# Problem

The support for circular references added with #335 comes with a significant performance cost.
For every entity the list of already parsed entities is searched. This leads to non-linear performance characteristics.

# Solution

I’ve partitioned the visited entities lookup by ids. Entities with a different type that share the same id will still be added to a list, which shouldn't be a problem in practice. Using a Set would have been simpler, but that was ruled out [earlier](https://github.com/paularmstrong/normalizr/pull/330#discussion_r179919159).

## Performance comparison

### Setup

```
const mySchema = new schema.Entity('tacos');
const data = [];
for (let i = 0; i < N; i++) {
  data.push({ id: i, type: `foo-${i}` });
}
normalize(data, [mySchema]);
```

### Normalization times in milliseconds for 5 runs

|N = 10,000 entities   |  |  |  |  |          |
| -------- | ---:| ---:| ---:| ---:| ---:|
|current      |157|141|139|148|142|
|optimized | 38|  37|  39| 38|  36|

|N = 100,000 entities  |  |  |  |  |                   |
| -------- | ----:| ----:| ----:| ----:| ----:|
|current      |6696|6738|6762|6772|6673|
|optimized |  255|   248|    259|   257|   241|

# TODO

- [ ] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
