### PR TITLE
added a fallback strategy for denormalization

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -175,6 +175,9 @@ const normalizedData = normalize(data, myArray);
     - `value`: The input value of the entity.
     - `parent`: The parent object of the input array.
     - `key`: The key at which the input array appears on the parent object.
+  - `fallbackStrategy(key, schema)`: Strategy to use when denormalizing data structures with id references to missing entities.
+    - `key`: The key at which the input array appears on the parent object.
+    - `schema`: The schema of the missing entity
 
 #### Instance Methods
 
@@ -251,6 +254,56 @@ normalize(data, [patronsSchema]);
   },
   result: ['1', '1-22']
 }
+```
+
+#### `fallbackStrategy` Usage
+```js
+const users = [
+  { id: '1', name: "Emily", requestState: 'SUCCEEDED' },
+  { id: '2', name: "Douglas", requestState: 'SUCCEEDED' }
+];
+const books = [
+  {id: '1', name: "Book 1", author: 1 },
+  {id: '2', name: "Book 2", author: 2 },
+  {id: '3', name: "Book 3", author: 3 }
+]
+
+const authorSchema = new schema.Entity('authors');
+const bookSchema = new schema.Entity('books', {
+  author: authorSchema
+}, {
+  fallbackStrategy: (key, schema) => {
+    return {
+      [schema.idAttribute]: key,
+      name: 'Unknown',
+      requestState: 'NONE'
+    };
+  }
+});
+
+```
+
+
+#### Output
+```js
+[
+  {
+    id: '1', 
+    name: "Book 1", 
+    author: { id: '1', name: "Emily", requestState: 'SUCCEEDED' }
+  },
+  {
+    id: '2', 
+    name: "Book 2", 
+    author: { id: '2', name: "Douglas", requestState: 'SUCCEEDED' },
+  },
+  {
+    id: '3', 
+    name: "Book 3", 
+    author: { id: '3', name: "Unknown", requestState: 'NONE' },
+  }
+]
+
 ```
 
 ### `Object(definition)`

--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,12 @@ export const normalize = (input, schema) => {
 };
 
 const unvisitEntity = (id, schema, unvisit, getEntity, cache) => {
-  const entity = getEntity(id, schema);
+  let entity = getEntity(id, schema);
+
+  if (entity === undefined && schema instanceof EntitySchema) {
+    entity = schema.fallback(entity, id);
+  }
+
   if (typeof entity !== 'object' || entity === null) {
     return entity;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,7 @@ const unvisitEntity = (id, schema, unvisit, getEntity, cache) => {
   let entity = getEntity(id, schema);
 
   if (entity === undefined && schema instanceof EntitySchema) {
-    entity = schema.fallback(entity, id);
+    entity = schema.fallback(id, schema);
   }
 
   if (typeof entity !== 'object' || entity === null) {

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -15,7 +15,7 @@ export default class EntitySchema {
         return { ...entityA, ...entityB };
       },
       processStrategy = (input) => ({ ...input }),
-      fallbackStrategy = (input, key) => input
+      fallbackStrategy = (key, schema) => undefined
     } = options;
 
     this._key = key;
@@ -50,8 +50,8 @@ export default class EntitySchema {
     return this._mergeStrategy(entityA, entityB);
   }
 
-  fallback(input, id) {
-    return this._fallbackStrategy(input, id);
+  fallback(id, schema) {
+    return this._fallbackStrategy(id, schema);
   }
 
   normalize(input, parent, key, visit, addEntity, visitedEntities) {

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -14,7 +14,8 @@ export default class EntitySchema {
       mergeStrategy = (entityA, entityB) => {
         return { ...entityA, ...entityB };
       },
-      processStrategy = (input) => ({ ...input })
+      processStrategy = (input) => ({ ...input }),
+      fallbackStrategy = (input, key) => input
     } = options;
 
     this._key = key;
@@ -22,6 +23,7 @@ export default class EntitySchema {
     this._idAttribute = idAttribute;
     this._mergeStrategy = mergeStrategy;
     this._processStrategy = processStrategy;
+    this._fallbackStrategy = fallbackStrategy;
     this.define(definition);
   }
 
@@ -46,6 +48,10 @@ export default class EntitySchema {
 
   merge(entityA, entityB) {
     return this._mergeStrategy(entityA, entityB);
+  }
+
+  fallback(input, id) {
+    return this._fallbackStrategy(input, id);
   }
 
   normalize(input, parent, key, visit, addEntity, visitedEntities) {

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -292,4 +292,39 @@ describe(`${schema.Entity.name} denormalization`, () => {
     // NOTE: Given how immutable data works, referential equality can't be
     // maintained with nested denormalization.
   });
+
+  test('denormalizes with fallback strategy', () => {
+    const user = new schema.Entity(
+      'users',
+      {},
+      {
+        fallbackStrategy: (entity, id) => ({
+          id: id,
+          name: 'John Doe'
+        })
+      }
+    );
+    const report = new schema.Entity('reports', {
+      draftedBy: user,
+      publishedBy: user
+    });
+
+    const entities = {
+      reports: {
+        '123': {
+          id: '123',
+          title: 'Weekly report',
+          draftedBy: '456',
+          publishedBy: '456'
+        }
+      },
+      users: {}
+    };
+
+    const denormalizedReport = denormalize('123', report, entities);
+
+    expect(denormalizedReport.publishedBy).toBe(denormalizedReport.draftedBy);
+    expect(denormalizedReport.publishedBy.name).toBe('John Doe');
+    //
+  });
 });

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -298,8 +298,9 @@ describe(`${schema.Entity.name} denormalization`, () => {
       'users',
       {},
       {
-        fallbackStrategy: (entity, id) => ({
-          id: id,
+        idAttribute: 'userId',
+        fallbackStrategy: (id, schema) => ({
+          [schema.idAttribute]: id,
           name: 'John Doe'
         })
       }
@@ -325,6 +326,7 @@ describe(`${schema.Entity.name} denormalization`, () => {
 
     expect(denormalizedReport.publishedBy).toBe(denormalizedReport.draftedBy);
     expect(denormalizedReport.publishedBy.name).toBe('John Doe');
+    expect(denormalizedReport.publishedBy.userId).toBe('456');
     //
   });
 });


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->

# Problem

In some cases I would like to denormalize a structure with a list of Ids instead of a list of subobjects (reasons could be to limit fetched data). When i normalize this structure the normalization works, I am left with the entity ids, but there is no way to create stubs for the entities itself, which I find ok since there could be an instance of the same object somewhere else in the structure.

But when denormalizing this I will get back an array with undefined items. 

# Solution

A possible solution to this could be to add a possibility to add a fallbackStrategy option to the EntitySchema where we could write our own fallback method for denormalization.
# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation
