### PR TITLE
Enable loose transformation for object spread operator to improve per…

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -6,7 +6,7 @@ module.exports = {
   presets: [['@babel/preset-env', { loose: true }]],
   plugins: [
     // cjs && 'transform-es2015-modules-commonjs',
-    '@babel/plugin-proposal-object-rest-spread',
+    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }]
   ].filter(Boolean)
 };


### PR DESCRIPTION
# Problem

Upgrading to babel 7 has significantly worsened the normalization performance, which is part of the reason for [https://github.com/paularmstrong/normalizr/issues/383](https://github.com/paularmstrong/normalizr/issues/383). With Babel 7 the transpilation of the spread operator changed from a simple `Object.assign` to a more complicate logic [https://babeljs.io/docs/en/v7-migration#babel-plugin-proposal-object-rest-spread](https://babeljs.io/docs/en/v7-migration#babel-plugin-proposal-object-rest-spread). Spreading is used as `processStrategy` and `mergeStrategy` which became a lot more expensive.  

# Solution

Enable "loose" transformation for object spreading.

## Performance comparison

### Setup

```
const mySchema = new schema.Entity('tacos');
const data = [];
for (let i = 0; i < N; i++) {
  data.push({ id: i, type: `foo-${i}` });
}
normalize(data, [mySchema]);
```

### Normalization times in milliseconds for 5 runs

|N = 10,000 entities   |  |  |  |  |          |
| -------- | ---:| ---:| ---:| ---:| ---:|
|current              | 27| 22| 22| 22| 21|
|loose transformation | 17|  9| 11|  9| 12|

|N = 100,000 entities  |  |  |  |  |          |
| -------- | ----:| ----:| ----:| ----:| ----:|
|current              | 210| 201| 200| 200| 198|
|loose transformation |  97| 111|  97|  97|  94|

# TODO

- [ ] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation