### PR TITLE
fix(typescript): entities undefined if none found

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ export interface SchemaArray<T> extends Array<Schema<T>> {}
 
 export type NormalizedSchema<E, R> = { entities: E, result: R };
 
-export function normalize<T = any, E = { [key:string]: { [key:string]: T }}, R = any>(
+export function normalize<T = any, E = { [key:string]: { [key:string]: T } | undefined}, R = any>(
   data: any,
   schema: Schema<T>
 ): NormalizedSchema<E, R>;


### PR DESCRIPTION
# Problem

When there are no items found for a particular entity, normalizr returns nothing for that entity.

The problem is that the TypeScript definitions expect there to always be an object, so TypeScript fails to catch issues which later appear at runtime as `undefined` type errors.

# Solution

Normalizr's behavior in this area has been discussed here before: https://github.com/paularmstrong/normalizr/issues/290 

This PR doesn't change that, it just updates the TypeScript definition to match what Normalizr already returns.

Only issue is TypeScript will warn existing users about this error. It highlights a real potential bug in their system that it wasn't able to spot before, but likely to need users to fix their use of the result.entities object (or set `{}` as a default for undefined entities).

# TODO

- [x] Add & update tests - NA, no TS definition tests.
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation - NA, no change to existing behavior.
