### PR TITLE
Add types for fallback strategy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ declare namespace schema {
   export type StrategyFunction<T> = (value: any, parent: any, key: string) => T;
   export type SchemaFunction = (value: any, parent: any, key: string) => string;
   export type MergeFunction = (entityA: any, entityB: any) => any;
+  export type FallbackFunction<T> = (key: string, schema: schema.Entity<T>) => T;
 
   export class Array<T = any> {
     constructor(definition: Schema<T>, schemaAttribute?: string | SchemaFunction)
@@ -12,6 +13,7 @@ declare namespace schema {
     idAttribute?: string | SchemaFunction
     mergeStrategy?: MergeFunction
     processStrategy?: StrategyFunction<T>
+    fallbackStrategy?: FallbackFunction<T>
   }
 
   export class Entity<T = any> {

--- a/typescript-tests/entity.ts
+++ b/typescript-tests/entity.ts
@@ -14,7 +14,11 @@ type Tweet = {
 const data = {
   /* ...*/
 };
-const user = new schema.Entity('users', {}, { idAttribute: 'id_str' });
+const user = new schema.Entity<User>(
+  'users',
+  {},
+  { idAttribute: 'id_str', fallbackStrategy: (key) => ({ id_str: key, name: 'Unknown' }) }
+);
 const tweet = new schema.Entity(
   'tweets',
   { user: user },


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

3.6.0 release introduces `fallbackStrategy` method, which is not usable with typescript, because of missing types

# Solution

Add missing types

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation

I also noticed that while prettier is installed in this project, it wasn't used on every file, I did that initially and the diff was much larger, which is out of scope of this particular PR, but I could do that separately  if you'd like.