### PR TITLE
feat(entity) add key naming strategy

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare namespace schema {
     idAttribute?: string | SchemaFunction
     mergeStrategy?: MergeFunction
     processStrategy?: StrategyFunction<T>
-    fallbackStrategy?: FallbackFunction<T>,
+    fallbackStrategy?: FallbackFunction<T>
     keyNamingStrategy?: 'camelCase' | 'snakeCase' | null
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,8 @@ declare namespace schema {
     idAttribute?: string | SchemaFunction
     mergeStrategy?: MergeFunction
     processStrategy?: StrategyFunction<T>
-    fallbackStrategy?: FallbackFunction<T>
+    fallbackStrategy?: FallbackFunction<T>,
+    keyNamingStrategy?: 'camelCase' | 'snakeCase' | null
   }
 
   export class Entity<T = any> {

--- a/src/schemas/Entity.js
+++ b/src/schemas/Entity.js
@@ -15,7 +15,8 @@ export default class EntitySchema {
         return { ...entityA, ...entityB };
       },
       processStrategy = (input) => ({ ...input }),
-      fallbackStrategy = (key, schema) => undefined
+      fallbackStrategy = (key, schema) => undefined,
+      keyNamingStrategy
     } = options;
 
     this._key = key;
@@ -24,6 +25,13 @@ export default class EntitySchema {
     this._mergeStrategy = mergeStrategy;
     this._processStrategy = processStrategy;
     this._fallbackStrategy = fallbackStrategy;
+
+    this._keyNameAffix = '';
+    if (keyNamingStrategy === 'camelCase') {
+      this._keyNameAffix = 'Id';
+    } else if (keyNamingStrategy === 'snakeCase') {
+      this._keyNameAffix = '_id';
+    }
     this.define(definition);
   }
 
@@ -54,6 +62,17 @@ export default class EntitySchema {
     return this._fallbackStrategy(id, schema);
   }
 
+  getKeyName(key, schema) {
+    if (!this._keyNameAffix) {
+      return key;
+    }
+    if (Array.isArray(schema)) {
+      return `${key}${this._keyNameAffix}s`;
+    } else {
+      return `${key}${this._keyNameAffix}`;
+    }
+  }
+
   normalize(input, parent, key, visit, addEntity, visitedEntities) {
     const id = this.getId(input, parent, key);
     const entityType = this.key;
@@ -74,14 +93,19 @@ export default class EntitySchema {
       if (processedEntity.hasOwnProperty(key) && typeof processedEntity[key] === 'object') {
         const schema = this.schema[key];
         const resolvedSchema = typeof schema === 'function' ? schema(input) : schema;
-        processedEntity[key] = visit(
+
+        const idKey = this.getKeyName(key, resolvedSchema);
+        processedEntity[idKey] = visit(
           processedEntity[key],
           processedEntity,
-          key,
+          idKey,
           resolvedSchema,
           addEntity,
           visitedEntities
         );
+        if (idKey !== key) {
+          delete processedEntity[key];
+        }
       }
     });
 
@@ -95,9 +119,10 @@ export default class EntitySchema {
     }
 
     Object.keys(this.schema).forEach((key) => {
-      if (entity.hasOwnProperty(key)) {
-        const schema = this.schema[key];
-        entity[key] = unvisit(entity[key], schema);
+      const schema = this.schema[key];
+      const idKey = this.getKeyName(key, schema);
+      if (entity.hasOwnProperty(idKey)) {
+        entity[key] = unvisit(entity[idKey], schema);
       }
     });
     return entity;

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -116,15 +116,9 @@ describe(`${schema.Entity.name} normalization`, () => {
   });
 
   describe('keyNamingStrategy', () => {
-    test('normalizes nested entities', () => {
+    test('normalizes nested entities with camelCase', () => {
       const user = new schema.Entity('users', {}, { keyNamingStrategy: 'camelCase' });
-      const comment = new schema.Entity(
-        'comments',
-        {
-          user: user
-        },
-        { keyNamingStrategy: 'camelCase' }
-      );
+      const comment = new schema.Entity('comments', {}, { keyNamingStrategy: 'camelCase' });
       const article = new schema.Entity(
         'articles',
         {
@@ -145,11 +139,37 @@ describe(`${schema.Entity.name} normalization`, () => {
         comments: [
           {
             id: 'comment-123-4738',
-            comment: 'I like it!',
-            user: {
-              id: '10293',
-              name: 'Jane'
-            }
+            comment: 'I like it!'
+          }
+        ]
+      };
+      expect(normalize(input, article)).toMatchSnapshot();
+    });
+
+    test('normalizes nested entities with snakeCase', () => {
+      const user = new schema.Entity('users', {}, { keyNamingStrategy: 'snakeCase' });
+      const comment = new schema.Entity('comments', {}, { keyNamingStrategy: 'snakeCase' });
+      const article = new schema.Entity(
+        'articles',
+        {
+          author: user,
+          comments: [comment]
+        },
+        { keyNamingStrategy: 'snakeCase' }
+      );
+
+      const input = {
+        id: '123',
+        title: 'A Great Article',
+        author: {
+          id: '8472',
+          name: 'Paul'
+        },
+        body: 'This article is great.',
+        comments: [
+          {
+            id: 'comment-123-4738',
+            comment: 'I like it!'
           }
         ]
       };

--- a/src/schemas/__tests__/Entity.test.js
+++ b/src/schemas/__tests__/Entity.test.js
@@ -114,6 +114,48 @@ describe(`${schema.Entity.name} normalization`, () => {
       expect(normalize({ message: { id: '123', data: { attachment: { id: '456' } } } }, myEntity)).toMatchSnapshot();
     });
   });
+
+  describe('keyNamingStrategy', () => {
+    test('normalizes nested entities', () => {
+      const user = new schema.Entity('users', {}, { keyNamingStrategy: 'camelCase' });
+      const comment = new schema.Entity(
+        'comments',
+        {
+          user: user
+        },
+        { keyNamingStrategy: 'camelCase' }
+      );
+      const article = new schema.Entity(
+        'articles',
+        {
+          author: user,
+          comments: [comment]
+        },
+        { keyNamingStrategy: 'camelCase' }
+      );
+
+      const input = {
+        id: '123',
+        title: 'A Great Article',
+        author: {
+          id: '8472',
+          name: 'Paul'
+        },
+        body: 'This article is great.',
+        comments: [
+          {
+            id: 'comment-123-4738',
+            comment: 'I like it!',
+            user: {
+              id: '10293',
+              name: 'Jane'
+            }
+          }
+        ]
+      };
+      expect(normalize(input, article)).toMatchSnapshot();
+    });
+  });
 });
 
 describe(`${schema.Entity.name} denormalization`, () => {
@@ -328,5 +370,54 @@ describe(`${schema.Entity.name} denormalization`, () => {
     expect(denormalizedReport.publishedBy.name).toBe('John Doe');
     expect(denormalizedReport.publishedBy.userId).toBe('456');
     //
+  });
+
+  test('denormalizes nested entities with keyNamingStrategy', () => {
+    const user = new schema.Entity('users', {}, { keyNamingStrategy: 'camelCase' });
+    const comment = new schema.Entity(
+      'comments',
+      {
+        user: user
+      },
+      { keyNamingStrategy: 'camelCase' }
+    );
+    const article = new schema.Entity(
+      'articles',
+      {
+        author: user,
+        comments: [comment]
+      },
+      { keyNamingStrategy: 'camelCase' }
+    );
+
+    const entities = {
+      articles: {
+        '123': {
+          authorId: '8472',
+          body: 'This article is great.',
+          commentsIds: ['comment-123-4738'],
+          id: '123',
+          title: 'A Great Article'
+        }
+      },
+      comments: {
+        'comment-123-4738': {
+          comment: 'I like it!',
+          id: 'comment-123-4738',
+          userId: '10293'
+        }
+      },
+      users: {
+        '10293': {
+          id: '10293',
+          name: 'Jane'
+        },
+        '8472': {
+          id: '8472',
+          name: 'Paul'
+        }
+      }
+    };
+    expect(denormalize('123', article, entities)).toMatchSnapshot();
   });
 });

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -289,7 +289,7 @@ Object {
 }
 `;
 
-exports[`EntitySchema normalization keyNamingStrategy normalizes nested entities 1`] = `
+exports[`EntitySchema normalization keyNamingStrategy normalizes nested entities with camelCase 1`] = `
 Object {
   "entities": Object {
     "articles": Object {
@@ -307,14 +307,40 @@ Object {
       "comment-123-4738": Object {
         "comment": "I like it!",
         "id": "comment-123-4738",
-        "userId": "10293",
       },
     },
     "users": Object {
-      "10293": Object {
-        "id": "10293",
-        "name": "Jane",
+      "8472": Object {
+        "id": "8472",
+        "name": "Paul",
       },
+    },
+  },
+  "result": "123",
+}
+`;
+
+exports[`EntitySchema normalization keyNamingStrategy normalizes nested entities with snakeCase 1`] = `
+Object {
+  "entities": Object {
+    "articles": Object {
+      "123": Object {
+        "author_id": "8472",
+        "body": "This article is great.",
+        "comments_ids": Array [
+          "comment-123-4738",
+        ],
+        "id": "123",
+        "title": "A Great Article",
+      },
+    },
+    "comments": Object {
+      "comment-123-4738": Object {
+        "comment": "I like it!",
+        "id": "comment-123-4738",
+      },
+    },
+    "users": Object {
       "8472": Object {
         "id": "8472",
         "name": "Paul",

--- a/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
+++ b/src/schemas/__tests__/__snapshots__/Entity.test.js.snap
@@ -94,6 +94,33 @@ Immutable.Record {
 }
 `;
 
+exports[`EntitySchema denormalization denormalizes nested entities with keyNamingStrategy 1`] = `
+Object {
+  "author": Object {
+    "id": "8472",
+    "name": "Paul",
+  },
+  "authorId": "8472",
+  "body": "This article is great.",
+  "comments": Array [
+    Object {
+      "comment": "I like it!",
+      "id": "comment-123-4738",
+      "user": Object {
+        "id": "10293",
+        "name": "Jane",
+      },
+      "userId": "10293",
+    },
+  ],
+  "commentsIds": Array [
+    "comment-123-4738",
+  ],
+  "id": "123",
+  "title": "A Great Article",
+}
+`;
+
 exports[`EntitySchema denormalization denormalizes recursive dependencies 1`] = `
 Object {
   "draftedBy": Object {
@@ -259,6 +286,42 @@ Object {
     },
   },
   "result": "134351",
+}
+`;
+
+exports[`EntitySchema normalization keyNamingStrategy normalizes nested entities 1`] = `
+Object {
+  "entities": Object {
+    "articles": Object {
+      "123": Object {
+        "authorId": "8472",
+        "body": "This article is great.",
+        "commentsIds": Array [
+          "comment-123-4738",
+        ],
+        "id": "123",
+        "title": "A Great Article",
+      },
+    },
+    "comments": Object {
+      "comment-123-4738": Object {
+        "comment": "I like it!",
+        "id": "comment-123-4738",
+        "userId": "10293",
+      },
+    },
+    "users": Object {
+      "10293": Object {
+        "id": "10293",
+        "name": "Jane",
+      },
+      "8472": Object {
+        "id": "8472",
+        "name": "Paul",
+      },
+    },
+  },
+  "result": "123",
 }
 `;
 


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

It's just confuse to having the same property sometimes to be Id, sometimes to be an object/array. And that problem is particularly annoying when it comes to using TypeScript, as user have to define the type either like `user: number|User` or `user: any`. 

Found one issue on this one.
https://github.com/paularmstrong/normalizr/issues/423

# Solution

Add an optional option to suffixed id to the property.

```js
      const user = new schema.Entity('users', {}, { keyNamingStrategy: 'camelCase' });
      const comment = new schema.Entity('comments', {}, { keyNamingStrategy: 'camelCase' });
      const article = new schema.Entity(
        'articles',
        {
          author: user,
          comments: [comment]
        },
        { keyNamingStrategy: 'camelCase' }
      );

      const input = {
        id: '123',
        title: 'A Great Article',
        author: {
          id: '8472',
          name: 'Paul'
        },
        body: 'This article is great.',
        comments: [
          {
            id: 'comment-123-4738',
            comment: 'I like it!'
          }
        ]
      };
```
result
```typescript
"entities": Object {
    "articles": Object {
      "123": Object {
        "authorId": "8472",
        "body": "This article is great.",
        "commentsIds": Array [
          "comment-123-4738",
        ],
        "id": "123",
        "title": "A Great Article",
      },
    },
    "comments": Object {
      "comment-123-4738": Object {
        "comment": "I like it!",
        "id": "comment-123-4738",
      },
    },
    "users": Object {
      "8472": Object {
        "id": "8472",
        "name": "Paul",
      },
    },
  },
  "result": "123",
```

# TODO

- [x] Add & update tests
- [x] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
