### PR TITLE
Augment types for denomalize

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -64,8 +64,8 @@ export function normalize<T = any, E = { [key:string]: { [key:string]: T } | und
   schema: Schema<T>
 ): NormalizedSchema<E, R>;
 
-export function denormalize(
+export function denormalize<T>(
   input: any,
-  schema: Schema,
+  schema: Schema<T>,
   entities: any
-): any;
+): T;


### PR DESCRIPTION
I added a type variable for denormalization so the return type of `denormalize` gets automatically inferred from the type of the generic `Schema<T>` and therefor for edample from `schema.Entity<T>`.

<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem

When using denomralize with TypeScript, the return type is always any, as specified. In my opinion, we can do a lot better by returning the type-argument of the `Schema` which you can set e.g. by calling `new schema.Entity<EntityType>(...)`.

# Solution

I used a generic type-argument to pick up the specified type for the Schema and return it.

# TODO

- [ ] Add & update tests
- [ ] Ensure CI is passing (lint, tests, flow)
- [ ] Update relevant documentation
