### PR TITLE
Explicitly export schema namespace

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare namespace schema {
+export namespace schema {
   export type StrategyFunction<T> = (value: any, parent: any, key: string) => T;
   export type SchemaFunction = (value: any, parent: any, key: string) => string;
   export type MergeFunction = (entityA: any, entityB: any) => any;


### PR DESCRIPTION
<!--
Thank you so much for contributing to open source and the Normalizr project!
-->
# Problem
It is not clear that the `schema` namespace is being exported. Seasoned TypeScript developers will know that namespaces are
exported by default. But it can can be confusing for unexperienced people or even for some tooling that relies on the `export` keyword.

It is a problem when using `eslint-plugin-import` with `import-resolver-typescript`. As it only considers explicitly exported names to be exported.

# Solution

I've exported the namespace explicitly.

# TODO

- [x] Add & update tests _(don't think we need to change any tests)_
- [x] Ensure CI is passing (lint, tests, flow)
- [x] Update relevant documentation _(don't think nothing would change on the documentation)_
